### PR TITLE
Adds Threshold to RowBased checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,22 @@ To validate an `.parquet` file, specify `parquetFile` and the path to the file, 
 
 ### Validators
 
-  The third section are the validators. To specify a validator, you first specify the type as one of the validators, then specify the arguments for that validator. Currently supported validators are listed below:
+  The third section are the validators. To specify a validator, you
+first specify the type as one of the validators, then specify the
+arguments for that validator. Some of the validators support an error
+threshold. This options allows the user specify the number of errors
+or percentage of errors they can tolerate.  In some use cases, it
+might not be possible to eliminate all errors in the data.
+
+##### Thresholds
+
+Thresholds can be specified as an absolute number of errors, or a percentage of the row count.
+If the threshold is `>= 1` it is considered an absolute number of errors. For example `1000` would fail the check if there are more then 1000 rows that failed the check.
+
+If the threshold is `< 1` it is considered a fraction of the row count. For example `0.25` would fail the check if more then `rowCount * 0.25` of the rows fail the check.
+If the threshold ends in a `%` its considered a percentage of the row count. For eample `33%` would fail the check if more then `rowCount * 0.33` of the rows fail the check.
+
+Currently supported validators are listed below:
 
 #### `columnMaxCheck`
 
@@ -230,6 +245,7 @@ Takes a single parameter, the column name to check. The validator will fail if a
 | Arg | Type | Description |
 |-----|------|-------------|
 | `column` | String | Table column to be checked for negative values.  If it contains a `null` validator will fail.  **Note:** Column must be of a `NumericType` or the check will fail during the config check.
+| `threshold` | String | See above description of threshold.
 
 #### `nullCheck`
 
@@ -238,6 +254,7 @@ Takes a single parameter, the column name to check. The validator will fail if a
 | Arg | Type | Description |
 |-----|------|-------------|
 | `column` | String | Table column to be checked for `null`.  If it contains a `null` validator will fail.
+| `threshold` | String | See above description of threshold.
 
 #### `rangeCheck`
 
@@ -249,6 +266,7 @@ Takes 2 - 4 parameters, described below. If the value in the column doesn't fall
 | `minValue` | \* | lower bound of the range, or other column in table. Type depends on the type of the `column`.
 | `maxValue` | \* | upper bound of the range, or other column in table. Type depends on the type of the `column`.
 | `inclusive` | Boolean | Include `minValue` and `maxValue` as part of the range.
+| `threshold` | String | See above description of threshold.
 
 **Note:** To specify another column in the table, you must prefix the column name with a **`** (backtick).
 

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Takes 2 - 4 parameters, described below. If the value in the column doesn't fall
 
 #### `stringLengthCheck`
 
-Takes 2 or 3 parameters, described in the table below. If the length of the string in the column doesn't fall within the range specified by (`minValue`, `maxValue`), both inclusive, the check will fail.
+Takes 2 to 4 parameters, described in the table below. If the length of the string in the column doesn't fall within the range specified by (`minValue`, `maxValue`), both inclusive, the check will fail.
 At least one of `minValue` or `maxValue` must be specified. The data type of `column` must be String.
 
 | Arg | Type | Description |
@@ -280,6 +280,7 @@ At least one of `minValue` or `maxValue` must be specified. The data type of `co
 | `column` | String | Table column to be checked. The DataType of the column must be a String
 | `minValue` | Integer | Lower bound of the length of the string, inclusive.
 | `maxValue` | Integer | Upper bound of the length of the string, inclusive.
+| `threshold` | String | See above description of threshold.
 
 #### `rowCount`
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ To validate an `.parquet` file, specify `parquetFile` and the path to the file, 
   The third section are the validators. To specify a validator, you
 first specify the type as one of the validators, then specify the
 arguments for that validator. Some of the validators support an error
-threshold. This options allows the user specify the number of errors
+threshold. This options allows the user to specify the number of errors
 or percentage of errors they can tolerate.  In some use cases, it
 might not be possible to eliminate all errors in the data.
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ To validate an `.orc` file, specify `orcFile` and the path to the file, see belo
   checks:
 ```
 
+#### Parquet File
+
+To validate an `.parquet` file, specify `parquetFile` and the path to the file, see below.
+
+```yaml
+- parquetFile: /path/to/parquet/file
+  keyColumns:
+    - col1
+    - col2
+  checks:
+```
+
 ### Validators
 
   The third section are the validators. To specify a validator, you first specify the type as one of the validators, then specify the arguments for that validator. Currently supported validators are listed below:

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.1
+sbt.version = 1.2.7

--- a/src/main/scala/com/target/data_validator/JsonEncoders.scala
+++ b/src/main/scala/com/target/data_validator/JsonEncoders.scala
@@ -23,6 +23,7 @@ object JsonEncoders extends LazyLogging {
     override def apply(a: ValidatorEvent): Json = a match {
       case vc: ValidatorCounter => Json.obj(
         ("type", Json.fromString("counter")),
+        ("name", Json.fromString(vc.name)),
         ("value", Json.fromLong(vc.value))
       )
       case vg: ValidatorGood => Json.obj(

--- a/src/main/scala/com/target/data_validator/validator/ColumnBased.scala
+++ b/src/main/scala/com/target/data_validator/validator/ColumnBased.scala
@@ -1,6 +1,6 @@
 package com.target.data_validator.validator
 
-import com.target.data_validator.{ValidatorCheckEvent, ValidatorError, VarSubstitution}
+import com.target.data_validator.{ValidatorCheckEvent, ValidatorCounter, ValidatorError, VarSubstitution}
 import com.target.data_validator.JsonEncoders.eventEncoder
 import io.circe.Json
 import io.circe.syntax._
@@ -36,6 +36,7 @@ case class MinNumRows(minNumRows: Long) extends ColumnBased("", ValidatorBase.L0
 
   override def quickCheck(row: Row, count: Long, idx: Int): Boolean = {
     failed = count < minNumRows
+    addEvent(ValidatorCounter("rowCount", count))
     addEvent(ValidatorCheckEvent(failed, s"MinNumRowCheck $minNumRows ", count, 1))
     failed
   }
@@ -84,7 +85,6 @@ case class ColumnMaxCheck(column: String, value: Json)
         true // Fail check!
     }
     logger.debug(s"MaxValue compared Row: $row with value: $value failed: $failed")
-
     if (failed) {
       addEvent(
         ValidatorCheckEvent(

--- a/src/main/scala/com/target/data_validator/validator/JsonDecoders.scala
+++ b/src/main/scala/com/target/data_validator/validator/JsonDecoders.scala
@@ -10,8 +10,8 @@ object JsonDecoders extends LazyLogging {
   implicit val decodeChecks: Decoder[ValidatorBase] = new Decoder[ValidatorBase] {
     final def apply(c: HCursor): Decoder.Result[ValidatorBase] = c.downField("type").as[String].flatMap {
       case "rowCount" => c.as[MinNumRows]
-      case "nullCheck" => c.as[NullCheck]
-      case "negativeCheck" => c.as[NegativeCheck]
+      case "nullCheck" => NullCheck.fromJson(c)
+      case "negativeCheck" => NegativeCheck.fromJson(c)
       case "columnMaxCheck" => c.as[ColumnMaxCheck]
       case "rangeCheck" => RangeCheck.fromJson(c)
       case x => logger.error(s"Unknown Check `$x` in config!")

--- a/src/main/scala/com/target/data_validator/validator/NegativeCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/NegativeCheck.scala
@@ -1,0 +1,60 @@
+package com.target.data_validator.validator
+
+import com.target.data_validator.{ValidatorError, VarSubstitution}
+import com.target.data_validator.JsonEncoders.eventEncoder
+import com.target.data_validator.validator.ValidatorBase.I0
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.{DecodingFailure, HCursor, Json}
+import io.circe.syntax._
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{Expression, LessThan}
+import org.apache.spark.sql.types.{NumericType, StructType}
+
+case class NegativeCheck(column: String, threshold: Option[String]) extends RowBased {
+
+  override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
+    val ret = NegativeCheck(getVarSub(column, "column", dict),
+      threshold.map(getVarSub(_, "threshold", dict)))
+    getEvents.foreach(ret.addEvent)
+    ret
+  }
+
+  override def configCheck(df: DataFrame): Boolean = {
+    findColumnInDataFrame(df, column) match {
+      case Some(ft) if ft.dataType.isInstanceOf[NumericType] => Unit
+      case Some(ft) =>
+        val msg = s"Column: $column found, but not of numericType type: ${ft.dataType}"
+        logger.error(msg)
+        addEvent(ValidatorError(msg))
+      case None =>
+        val msg = s"Column: $column not found in schema."
+        logger.error(msg)
+        addEvent(ValidatorError(msg))
+    }
+    configCheckThreshold
+    failed
+  }
+
+  override def colTest(schema: StructType, dict: VarSubstitution): Expression =
+    LessThan (UnresolvedAttribute(column), I0)
+
+  override def toJson: Json = Json.obj(
+    ("type", Json.fromString("negativeCheck")),
+    ("column", Json.fromString(column)),
+    ("threshold", Json.fromString(threshold.getOrElse("0"))),
+    ("failed", Json.fromBoolean(failed)),
+
+    ("events", this.getEvents.asJson)
+  )
+}
+
+object NegativeCheck extends LazyLogging {
+  def fromJson(c: HCursor): Either[DecodingFailure, ValidatorBase] = {
+    val column = c.downField("column").as[String].right.get
+    val threshold = c.downField("threshold").as[String].right.toOption
+
+    logger.debug(s"Parsing NegativeCheck(column:$column, threshold:$threshold) config.")
+    scala.util.Right(NegativeCheck(column, threshold))
+  }
+}

--- a/src/main/scala/com/target/data_validator/validator/NegativeCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/NegativeCheck.scala
@@ -44,7 +44,6 @@ case class NegativeCheck(column: String, threshold: Option[String]) extends RowB
     ("column", Json.fromString(column)),
     ("threshold", Json.fromString(threshold.getOrElse("0"))),
     ("failed", Json.fromBoolean(failed)),
-
     ("events", this.getEvents.asJson)
   )
 }

--- a/src/main/scala/com/target/data_validator/validator/NullCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/NullCheck.scala
@@ -1,0 +1,40 @@
+package com.target.data_validator.validator
+
+import com.target.data_validator.JsonEncoders.eventEncoder
+import com.target.data_validator.VarSubstitution
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.{DecodingFailure, HCursor, Json}
+import io.circe.syntax._
+import org.apache.spark.sql.catalyst.analysis.UnresolvedAttribute
+import org.apache.spark.sql.catalyst.expressions.{Expression, IsNull}
+import org.apache.spark.sql.types.StructType
+
+case class NullCheck(column: String, threshold: Option[String]) extends RowBased {
+
+  override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
+    val ret = NullCheck(getVarSub(column, "column", dict),
+      threshold.map(getVarSub(_, "threshold", dict)))
+    getEvents.foreach(ret.addEvent)
+    ret
+  }
+
+  override def colTest(schema: StructType, dict: VarSubstitution): Expression = IsNull(UnresolvedAttribute(column))
+
+  override def toJson: Json = Json.obj(
+    ("type", Json.fromString("nullCheck")),
+    ("column", Json.fromString(column)),
+    ("failed", Json.fromBoolean(failed)),
+    ("events", this.getEvents.asJson)
+  )
+}
+
+object NullCheck extends LazyLogging {
+  def fromJson(c: HCursor): Either[DecodingFailure, ValidatorBase] = {
+    val column = c.downField("column").as[String].right.get
+    val threshold = c.downField("threshold").as[String].right.toOption
+
+    logger.debug(s"Parsing NullCheck(column:$column, threshold:$threshold) config.")
+    scala.util.Right(NullCheck(column, threshold))
+  }
+
+}

--- a/src/main/scala/com/target/data_validator/validator/RangeCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/RangeCheck.scala
@@ -15,16 +15,16 @@ case class RangeCheck(
   column: String,
   minValue: Option[Json],
   maxValue: Option[Json],
-  inclusive: Option[Json]
-) extends RowBased {
+  inclusive: Option[Json],
+  threshold: Option[String]) extends RowBased {
 
   override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
     val ret = RangeCheck(
       getVarSub(column, "column", dict),
       minValue.map(getVarSubJson(_, "minValue", dict)),
       maxValue.map(getVarSubJson(_, "maxValue", dict)),
-      inclusive.map(getVarSubJson(_, "inclusive", dict))
-    )
+      inclusive.map(getVarSubJson(_, "inclusive", dict)),
+      threshold.map(getVarSub(_, "threshold", dict)))
     getEvents.foreach(ret.addEvent)
     ret
   }
@@ -128,13 +128,15 @@ object RangeCheck extends LazyLogging {
     val minValueJ = c.downField("minValue").as[Json].right.toOption
     val maxValueJ = c.downField("maxValue").as[Json].right.toOption
     val inclusiveJ = c.downField("inclusive").as[Json].right.toOption
+    val threshold = c.downField("threshold").as[String].right.toOption
 
     logger.debug(s"column: $column")
     logger.debug(s"minValue: $minValueJ type: ${minValueJ.getClass.getCanonicalName}")
     logger.debug(s"maxValue: $maxValueJ type: ${maxValueJ.getClass.getCanonicalName}")
     logger.debug(s"inclusive: $inclusiveJ type: ${inclusiveJ.getClass.getCanonicalName}")
+    logger.debug(s"threshold: $threshold")
 
     c.focus.foreach {f => logger.info(s"RangeCheckJson: ${f.spaces2}")}
-    scala.util.Right(RangeCheck(column, minValueJ, maxValueJ, inclusiveJ))
+    scala.util.Right(RangeCheck(column, minValueJ, maxValueJ, inclusiveJ, threshold))
   }
 }

--- a/src/main/scala/com/target/data_validator/validator/RowBased.scala
+++ b/src/main/scala/com/target/data_validator/validator/RowBased.scala
@@ -1,7 +1,6 @@
 package com.target.data_validator.validator
 
-import com.target.data_validator.{ValidatorCheckEvent, ValidatorCounter, ValidatorError, ValidatorQuickCheckError}
-import com.target.data_validator.VarSubstitution
+import com.target.data_validator._
 import com.target.data_validator.validator.ValidatorBase.{isColumnInDataFrame, L0, L1}
 import org.apache.spark.sql.{DataFrame, Row}
 import org.apache.spark.sql.catalyst.expressions._
@@ -54,7 +53,7 @@ abstract class RowBased extends CheapCheck {
     * Calculates the max acceptable number of errors from threshold and rowCount.
     * @param rowCount of table.
     * @return max number of errors we can tolerate.
-    * if threshold < 0, then its a percentage of rowCount.
+    * if threshold < 1, then its a percentage of rowCount.
     * if threshold ends with '%' then its percentage of rowCount
     * if threshold is > 1, then its maxErrors.
     */
@@ -106,6 +105,6 @@ abstract class RowBased extends CheapCheck {
 }
 
 object RowBased {
-  val THRESHOLD_NUMBER_REGEX: Regex = "([0-9]+\\.*[0-9]*)\\s*%*".r
+  val THRESHOLD_NUMBER_REGEX: Regex = "^([0-9]+\\.*[0-9]*)\\s*%{0,1}$".r // scalastyle:ignore
 }
 

--- a/src/main/scala/com/target/data_validator/validator/RowBased.scala
+++ b/src/main/scala/com/target/data_validator/validator/RowBased.scala
@@ -61,8 +61,8 @@ abstract class RowBased extends CheapCheck {
     threshold.map { t =>
       val tempThreshold = t.stripSuffix("%").toDouble
       val ret: Long = if (t.endsWith("%")) {
-        // Has '%', so divide by 100.
-        (tempThreshold * (rowCount / 100)).toLong
+        // Has '%', so divide by 100.0
+        (tempThreshold * (rowCount / 100.0)).toLong
       } else if (tempThreshold < 1.0) {
         // Percentage without the '%'
         (tempThreshold * rowCount).toLong

--- a/src/main/scala/com/target/data_validator/validator/StringLengthCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/StringLengthCheck.scala
@@ -14,7 +14,8 @@ import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 case class StringLengthCheck(
                        column: String,
                        minValue: Option[Json],
-                       maxValue: Option[Json]
+                       maxValue: Option[Json],
+                       threshold: Option[String]
                      ) extends RowBased {
 
   override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
@@ -22,7 +23,8 @@ case class StringLengthCheck(
     val ret = StringLengthCheck(
                                   getVarSub(column, "column", dict),
                                   minValue.map(getVarSubJson(_, "minValue", dict)),
-                                  maxValue.map(getVarSubJson(_, "maxValue", dict))
+                                  maxValue.map(getVarSubJson(_, "maxValue", dict)),
+                                  threshold.map(getVarSub(_, "threshold", dict))
                                )
     getEvents.foreach(ret.addEvent)
     ret
@@ -115,12 +117,14 @@ object StringLengthCheck extends LazyLogging {
     val column = c.downField("column").as[String].right.get
     val minValueJ = c.downField("minValue").as[Json].right.toOption
     val maxValueJ = c.downField("maxValue").as[Json].right.toOption
+    val threshold = c.downField("threshold").as[String].right.toOption
 
     logger.debug(s"column: $column")
     logger.debug(s"minValue: $minValueJ type: ${minValueJ.getClass.getCanonicalName}")
     logger.debug(s"maxValue: $maxValueJ type: ${maxValueJ.getClass.getCanonicalName}")
+    logger.debug(s"threshold: $threshold type: ${threshold.getClass.getCanonicalName}")
 
     c.focus.foreach {f => logger.info(s"StringLengthCheckJson: ${f.spaces2}")}
-    scala.util.Right(StringLengthCheck(column, minValueJ, maxValueJ))
+    scala.util.Right(StringLengthCheck(column, minValueJ, maxValueJ, threshold))
   }
 }

--- a/src/test/scala/com/target/TestHelpers.scala
+++ b/src/test/scala/com/target/TestHelpers.scala
@@ -1,0 +1,59 @@
+package com.target.data_validator
+
+import io.circe.Json
+import io.circe.yaml.parser
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types.{BooleanType, DataType, DoubleType, IntegerType, LongType, StringType, StructField, StructType}
+
+object TestHelpers {
+
+
+  def parseYaml(yaml: String): Json = {
+    parser.parse(yaml).right.getOrElse(Json.Null)
+  }
+
+  def mkDict(args: (String, String)*): VarSubstitution = {
+    val ret = new VarSubstitution
+    args.foreach(kv => ret.addString(kv._1, kv._2))
+    ret
+  }
+
+  def guessType(v: Any): DataType = v.getClass.getCanonicalName match {
+    case "java.lang.String" => StringType
+    case "java.lang.Integer" => IntegerType
+    case "java.lang.Double" => DoubleType
+    case "java.lang.Boolean" => BooleanType
+    case _ => throw new IllegalArgumentException(s"Unknown type '${v.getClass.getCanonicalName}'")
+  }
+
+  def mkSchema(args: (String, List[Any])*): StructType = {
+    StructType(args.map(x => StructField(x._1, guessType(x._2.head))))
+  }
+
+  def mkRows(args: (String, List[Any])*): List[Row] = {
+    val len = args.head._2.length
+    require(args.forall(_._2.length == len))
+    (0 until len).map(i => Row(args.map(_._2.apply(i)): _*)).toList
+  }
+
+  /**
+    * creates dataFrame from array of (label, List[Any])
+    * @param spark
+    * @param args - is array of tuple(String, List[Any]) supported types are String, Double, Int, Long
+    * @return DataFrame
+    *
+    * ie mkDf(("item"     -> List("Eggs", "Milk", "Bread", "Cheese")),
+    *         ("price"    -> List(  5.49,   3.89,    4.50,     6.00),
+    *         ("quantity" -> List(    12,      5,       2,       10)))
+    *
+    * will return a dataframe
+    *
+    *
+    */
+  def mkDf(spark: SparkSession, args: (String, List[Any])*): DataFrame = {
+    require(args.forall(_._2.length == args.head._2.length))
+    val schema = mkSchema(args: _*)
+    val data = mkRows(args: _*)
+    spark.createDataFrame(spark.sparkContext.parallelize(data), schema)
+  }
+}

--- a/src/test/scala/com/target/data_validator/ConfigParserSpec.scala
+++ b/src/test/scala/com/target/data_validator/ConfigParserSpec.scala
@@ -28,10 +28,10 @@ class ConfigParserSpec extends FunSpec with BeforeAndAfterAll {
         "bar",
         Some(List("one", "two")),
         None,
-        List(MinNumRows(10294), NullCheck("mdse_item_i")) // scalastyle:ignore magic.number
+        List(MinNumRows(10294), NullCheck("mdse_item_i", None)) // scalastyle:ignore magic.number
       ),
-      ValidatorOrcFile("LocalFile.orc", None, Some("foo < 10"), List(NullCheck("start_d"))),
-      ValidatorParquetFile("LocFile.parquet", None, Some("bar < 10"), List(NullCheck("end_d")))
+      ValidatorOrcFile("LocalFile.orc", None, Some("foo < 10"), List(NullCheck("start_d", None))),
+      ValidatorParquetFile("LocFile.parquet", None, Some("bar < 10"), List(NullCheck("end_d", None)))
     )
   )
 

--- a/src/test/scala/com/target/data_validator/ConfigVarSubSpec.scala
+++ b/src/test/scala/com/target/data_validator/ConfigVarSubSpec.scala
@@ -95,12 +95,12 @@ class ConfigVarSubSpec extends FunSpec with Matchers with TestingSparkSession {
         describe("NegativeCheck") {
 
           it("NegativeCheck") {
-            val sut = NegativeCheck("Col$four")
-            assert(sut.substituteVariables(dict) == NegativeCheck("Col4"))
+            val sut = NegativeCheck("Col$four", None)
+            assert(sut.substituteVariables(dict) == NegativeCheck("Col4", None))
           }
 
           it("NegativeCheck bad variable substitution should fail") {
-            val check = NegativeCheck("Col$fourfour")
+            val check = NegativeCheck("Col$fourfour", None)
             val sut = check.substituteVariables(dict)
             assert(sut.failed)
           }
@@ -110,12 +110,12 @@ class ConfigVarSubSpec extends FunSpec with Matchers with TestingSparkSession {
         describe("NullCheck") {
 
           it("should substitute variables properly") {
-            val sut = NullCheck("Col${one}")
-            assert(sut.substituteVariables(dict) == NullCheck("Col1"))
+            val sut = NullCheck("Col${one}", None)
+            assert(sut.substituteVariables(dict) == NullCheck("Col1", None))
           }
 
           it("bad variable substitution should fail") {
-            val check = NullCheck("Col${unknown}")
+            val check = NullCheck("Col${unknown}", None)
             val sut = check.substituteVariables(dict)
             assert(sut.failed)
           }

--- a/src/test/scala/com/target/data_validator/TestHelpers.scala
+++ b/src/test/scala/com/target/data_validator/TestHelpers.scala
@@ -3,7 +3,7 @@ package com.target.data_validator
 import io.circe.Json
 import io.circe.yaml.parser
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
-import org.apache.spark.sql.types.{BooleanType, DataType, DoubleType, IntegerType, LongType, StringType, StructField, StructType}
+import org.apache.spark.sql.types._
 
 object TestHelpers {
 

--- a/src/test/scala/com/target/data_validator/ValidatorBaseSpec.scala
+++ b/src/test/scala/com/target/data_validator/ValidatorBaseSpec.scala
@@ -13,7 +13,7 @@ import org.scalatest._
 import scala.util.Random
 
 class ValidatorBaseSpec extends FunSpec with Matchers with TestingSparkSession {
-  val nullCheck = List(NullCheck("name"))
+  val nullCheck = List(NullCheck("name", None))
   val nameStructField = StructField("name", StringType)
   val schema = StructType(List(nameStructField, StructField("age", IntegerType)))
 
@@ -161,7 +161,7 @@ class ValidatorBaseSpec extends FunSpec with Matchers with TestingSparkSession {
     it("should fail configCheck on unknown column") {
       val dict = new VarSubstitution
       val df = spark.createDataFrame(sc.parallelize(List(Row("Doug", 50), Row("Collin", 32))), schema) //scalastyle:ignore
-      val config = mkConfig(df, List(NullCheck("unknown_column")))
+      val config = mkConfig(df, List(NullCheck("unknown_column", None)))
       assert(config.configCheck(spark, dict))
       assert(config.failed)
       assert(config.tables.head.failed)

--- a/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
+++ b/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
@@ -106,10 +106,10 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
         }
 
         it("checks") {
-          val vt = ValidatorHiveTable("database", "table", None, None, List(NullCheck("${nullCol1}")))
+          val vt = ValidatorHiveTable("database", "table", None, None, List(NullCheck("${nullCol1}", None)))
           val dict = mkDict(("nullCol1", "nc1"), ("nullCol2", "nc2"))
           val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorHiveTable]
-          assert(sut == vt.copy(checks = List(NullCheck("nc1"))))
+          assert(sut == vt.copy(checks = List(NullCheck("nc1", None))))
           assert(sut.checks.head.getEvents contains VarSubEvent("${nullCol1}", "nc1"))
         }
 
@@ -143,10 +143,10 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
         }
 
         it("checks") {
-          val vt = ValidatorOrcFile("OrcFile", None, None, List(NullCheck("${nullCol1}")))
+          val vt = ValidatorOrcFile("OrcFile", None, None, List(NullCheck("${nullCol1}", None)))
           val dict = mkDict(("nullCol1", "nc1"), ("nullCol2", "nc2"))
           val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorOrcFile]
-          assert(sut == vt.copy(checks = List(NullCheck("nc1"))))
+          assert(sut == vt.copy(checks = List(NullCheck("nc1", None))))
           assert(sut.checks.head.getEvents contains VarSubEvent("${nullCol1}", "nc1"))
         }
 
@@ -174,10 +174,10 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
         }
 
         it("checks") {
-          val vt = ValidatorDataFrame(spark.emptyDataFrame, None, None, List(NullCheck("$nullCol1")))
+          val vt = ValidatorDataFrame(spark.emptyDataFrame, None, None, List(NullCheck("$nullCol1", None)))
           val dict = mkDict(("nullCol1", "nc1"), ("nullCol2", "nc2"))
           val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorDataFrame]
-          assert(sut == vt.copy(checks = List(NullCheck("nc1"))))
+          assert(sut == vt.copy(checks = List(NullCheck("nc1", None))))
           assert(sut.checks.head.getEvents contains VarSubEvent("$nullCol1", "nc1"))
         }
 

--- a/src/test/scala/com/target/data_validator/validator/NegativeCheckSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/NegativeCheckSpec.scala
@@ -1,0 +1,132 @@
+package com.target.data_validator.validator
+
+import com.target.TestingSparkSession
+import com.target.data_validator.TestHelpers.{mkDf, mkDict, parseYaml}
+import com.target.data_validator.{ValidatorConfig, ValidatorDataFrame, ValidatorError}
+import org.scalatest.{FunSpec, Matchers}
+
+class NegativeCheckSpec extends FunSpec with Matchers with TestingSparkSession {
+
+  describe("NullCheck") {
+
+      describe("config parsing") {
+        it("basic config") {
+          val json = parseYaml(
+            """
+              |type: negativeCheck
+              |column: foo
+            """.stripMargin)
+
+          val sut = JsonDecoders.decodeChecks.decodeJson(json)
+          assert(sut == Right(NegativeCheck("foo", None)))
+        }
+
+        it("optional threshold") {
+          val json = parseYaml(
+            """
+              |type: negativeCheck
+              |column: foo
+              |threshold: 10.0%
+            """.stripMargin)
+
+          val sut = JsonDecoders.decodeChecks.decodeJson(json)
+          assert(sut == Right(NegativeCheck("foo", Some("10.0%"))))
+        }
+        it("config error") {
+          val json = parseYaml(
+            """
+              |type: negativeCheck
+              |garbage
+            """.stripMargin)
+
+          val sut = JsonDecoders.decodeChecks.decodeJson(json)
+          assert(sut.isLeft) // Todo: Maybe add better check. Left is generic failure.
+        }
+
+      }
+
+    describe("variable substitution") {
+      it("success substitution") {
+        var dict = mkDict("threshold" -> "20%", "column" -> "foo")
+        var sut = NegativeCheck("$column", Some("$threshold"))
+        assert(sut.substituteVariables(dict) == NegativeCheck("foo", Some("20%")))
+        assert(!sut.failed)
+      }
+
+      it("error on substitution issues") {
+        var dict = mkDict()
+        var sut = NegativeCheck("$column", Some("$threshold"))
+        assert(sut.substituteVariables(dict) == sut)
+        assert(sut.failed)
+        assert(sut.getEvents contains
+          ValidatorError("VariableSubstitution: Can't find values for the following keys, "
+            + "column"))
+        assert(sut.getEvents contains
+          ValidatorError("VariableSubstitution: Can't find values for the following keys, "
+            + "threshold"))
+      }
+    }
+
+    describe("check configuration") {
+      it("Column Exists") {
+        val df = mkDf(spark = spark, "price" -> List(1.99))
+        val sut = NegativeCheck("price", None)
+        assert(!sut.configCheck(df))
+      }
+
+      it("Column doesn't exist") {
+        val df = mkDf(spark = spark, ("price" -> List(1.99)))
+        val sut = NegativeCheck("junk", None)
+        assert(sut.configCheck(df))
+        assert(sut.failed)
+        assert(sut.getEvents contains ValidatorError("Column: junk not found in schema."))
+      }
+
+      it("Column exists but is wrong type") {
+        val df = mkDf(spark = spark, ("item" -> List("eggs")))
+        val sut = NegativeCheck("item", None)
+        assert(sut.configCheck(df))
+        assert(sut.failed)
+        assert(sut.getEvents contains ValidatorError("Column: item found, but not of numericType type: StringType"))
+      }
+
+    }
+
+    describe("functionality") {
+
+      it("success") {
+        val df = mkDf(spark, "price"-> List(1.99, 1.50, 2.50)) // scalastyle:ignore
+        val sut = ValidatorDataFrame(df, None, None, List(NegativeCheck("price", None)))
+        val config = ValidatorConfig(1, 1, None, false, None, None, List.empty)
+        assert(!sut.quickChecks(spark, mkDict())(config))
+        assert(!sut.failed)
+      }
+
+      it("fails") {
+        val df = mkDf(spark, "price"-> List(1.99, -1.50, 2.50)) // scalastyle:ignore
+        val sut = ValidatorDataFrame(df, None, None, List(NegativeCheck("price", None)))
+        val config = ValidatorConfig(1, 1, None, false, None, None, List.empty)
+        assert(sut.quickChecks(spark, mkDict())(config))
+        assert(sut.failed)
+
+      }
+
+      it("threshold success") {
+        val df = mkDf(spark, "price"-> List(1.99, -1.50, 2.50)) // scalastyle:ignore
+        val sut = ValidatorDataFrame(df, None, None, List(NegativeCheck("price", Some("1"))))
+        val config = ValidatorConfig(1, 1, None, false, None, None, List.empty)
+        assert(!sut.quickChecks(spark, mkDict())(config))
+        assert(!sut.failed)
+
+      }
+
+      it("threshold failure") {
+        val df = mkDf(spark, "price"-> List(1.99, -1.50, -2.50)) // scalastyle:ignore
+        val sut = ValidatorDataFrame(df, None, None, List(NegativeCheck("price", Some("1"))))
+        val config = ValidatorConfig(1, 1, None, false, None, None, List.empty)
+        assert(sut.quickChecks(spark, mkDict())(config))
+        assert(sut.failed)
+      }
+    }
+  }
+}

--- a/src/test/scala/com/target/data_validator/validator/NullCheckSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/NullCheckSpec.scala
@@ -1,8 +1,8 @@
 package com.target.data_validator.validator
 
 import com.target.TestingSparkSession
+import com.target.data_validator.{ValidatorConfig, ValidatorDataFrame, ValidatorError}
 import com.target.data_validator.TestHelpers._
-import com.target.data_validator.{ValidatorConfig, ValidatorDataFrame, ValidatorError, VarSubstitution}
 import org.scalatest.{FunSpec, Matchers}
 
 class NullCheckSpec extends FunSpec with Matchers with TestingSparkSession {
@@ -46,15 +46,15 @@ class NullCheckSpec extends FunSpec with Matchers with TestingSparkSession {
 
     describe("variable substitution") {
       it("success substitution") {
-        var dict = mkDict("threshold" -> "20%", "column" -> "foo")
-        var sut = NullCheck("$column", Some("$threshold"))
+        val dict = mkDict("threshold" -> "20%", "column" -> "foo")
+        val sut = NullCheck("$column", Some("$threshold"))
         assert(sut.substituteVariables(dict) == NullCheck("foo", Some("20%")))
         assert(!sut.failed)
       }
 
       it("error on substitution issues") {
-        var dict = mkDict()
-        var sut = NullCheck("$column", Some("$threshold"))
+        val dict = mkDict()
+        val sut = NullCheck("$column", Some("$threshold"))
         assert(sut.substituteVariables(dict) == sut)
         assert(sut.failed)
         assert(sut.getEvents contains
@@ -69,7 +69,7 @@ class NullCheckSpec extends FunSpec with Matchers with TestingSparkSession {
     describe("checkconfiguration") {
 
       it("Column Exists") {
-        val df = mkDf(spark = spark, ("item" -> List("Eggs")))
+        val df = mkDf(spark = spark, "item" -> List("Eggs"))
         val sut = NullCheck("item", None)
         assert(!sut.configCheck(df))
       }

--- a/src/test/scala/com/target/data_validator/validator/NullCheckSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/NullCheckSpec.scala
@@ -1,0 +1,124 @@
+package com.target.data_validator.validator
+
+import com.target.TestingSparkSession
+import com.target.data_validator.TestHelpers._
+import com.target.data_validator.{ValidatorConfig, ValidatorDataFrame, ValidatorError, VarSubstitution}
+import org.scalatest.{FunSpec, Matchers}
+
+class NullCheckSpec extends FunSpec with Matchers with TestingSparkSession {
+
+  describe("NullCheck") {
+    describe("config parsing") {
+      it("basic config") {
+        val json = parseYaml(
+          """
+            |type: nullCheck
+            |column: foo
+          """.stripMargin)
+
+        val sut = JsonDecoders.decodeChecks.decodeJson(json)
+        assert(sut == Right(NullCheck("foo", None)))
+      }
+
+      it("optional threshold") {
+        val json = parseYaml(
+          """
+            |type: nullCheck
+            |column: foo
+            |threshold: 10.0%
+          """.stripMargin)
+
+        val sut = JsonDecoders.decodeChecks.decodeJson(json)
+        assert(sut == Right(NullCheck("foo", Some("10.0%"))))
+      }
+      it("config error") {
+        val json = parseYaml(
+          """
+            |type: nullCheck
+            |garbage
+          """.stripMargin)
+
+        val sut = JsonDecoders.decodeChecks.decodeJson(json)
+        assert(sut.isLeft) // Todo: Maybe add better check. Left is generic failure.
+      }
+
+    }
+
+    describe("variable substitution") {
+      it("success substitution") {
+        var dict = mkDict("threshold" -> "20%", "column" -> "foo")
+        var sut = NullCheck("$column", Some("$threshold"))
+        assert(sut.substituteVariables(dict) == NullCheck("foo", Some("20%")))
+        assert(!sut.failed)
+      }
+
+      it("error on substitution issues") {
+        var dict = mkDict()
+        var sut = NullCheck("$column", Some("$threshold"))
+        assert(sut.substituteVariables(dict) == sut)
+        assert(sut.failed)
+        assert(sut.getEvents contains
+          ValidatorError("VariableSubstitution: Can't find values for the following keys, "
+        + "column"))
+        assert(sut.getEvents contains
+          ValidatorError("VariableSubstitution: Can't find values for the following keys, "
+            + "threshold"))
+      }
+    }
+
+    describe("checkconfiguration") {
+
+      it("Column Exists") {
+        val df = mkDf(spark = spark, ("item" -> List("Eggs")))
+        val sut = NullCheck("item", None)
+        assert(!sut.configCheck(df))
+      }
+
+      it("Column doesn't exist") {
+        val df = mkDf(spark = spark, "item" -> List("Eggs"),
+          "price" -> List(0.99), "perishable" -> List(true))
+        val sut = NullCheck("junk", None)
+        assert(sut.configCheck(df))
+        assert(sut.failed)
+        assert(sut.getEvents contains ValidatorError("Column: junk not found in schema."))
+      }
+    }
+
+    describe("functionality") {
+
+      it("success") {
+        val df = mkDf(spark, "item" -> List("item1", "item2", "item3"))
+        val sut = ValidatorDataFrame(df, None, None, List(NullCheck("item", None)))
+        val config = ValidatorConfig(1, 1, None, false, None, None, List.empty)
+        assert(!sut.quickChecks(spark, mkDict())(config))
+        assert(!sut.failed)
+      }
+
+      it("fails") {
+        val df = mkDf(spark, "item"-> List("item1", "item2", "item3", null)) // scalastyle:ignore
+        val sut = ValidatorDataFrame(df, None, None, List(NullCheck("item", None)))
+        val config = ValidatorConfig(1, 1, None, false, None, None, List.empty)
+        assert(sut.quickChecks(spark, mkDict())(config))
+        assert(sut.failed)
+
+      }
+
+      it("threshold success") {
+        val df = mkDf(spark, "item"-> List("item1", "item2", "item3", null)) // scalastyle:ignore
+        val sut = ValidatorDataFrame(df, None, None, List(NullCheck("item", Some("1"))))
+        val config = ValidatorConfig(1, 1, None, false, None, None, List.empty)
+        assert(!sut.quickChecks(spark, mkDict())(config))
+        assert(!sut.failed)
+
+      }
+
+      it("threshold failure") {
+        val df = mkDf(spark, "item"-> List("item1", "item2", "item3", null, null)) // scalastyle:ignore
+        val sut = ValidatorDataFrame(df, None, None, List(NullCheck("item", Some("1"))))
+        val config = ValidatorConfig(1, 1, None, false, None, None, List.empty)
+        assert(sut.quickChecks(spark, mkDict())(config))
+        assert(sut.failed)
+      }
+    }
+  }
+}

--- a/src/test/scala/com/target/data_validator/validator/RangeCheckSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/RangeCheckSpec.scala
@@ -187,7 +187,7 @@ class RangeCheckSpec extends FunSpec with Matchers with TestingSparkSession {
       it("min and max value") {
         val dict = new VarSubstitution
         val maxValue = Math.abs(Random.nextDouble)
-        val sut = RangeCheck("avg", Some(Json.fromInt(0)), Json.fromDouble(maxValue), None,  None)
+        val sut = RangeCheck("avg", Some(Json.fromInt(0)), Json.fromDouble(maxValue), None, None)
         // TODO: Find better way to compare expressions.
         assert(sut.colTest(schema, dict).sql ==
           Or(LessThanOrEqual(UnresolvedAttribute("avg"), D0),
@@ -281,14 +281,6 @@ class RangeCheckSpec extends FunSpec with Matchers with TestingSparkSession {
           ("events", Json.arr())
         ))
       }
-
-      it("threshold works as expected") {
-        val maxJson = Json.fromDouble(3.0)
-        val sut = RangeCheck("max",
-          None, maxJson, None, Some("30%")) // scalastyle:ignore
-        assert(true) // FIXME!!!!!
-      }
-
     }
 
     describe ("Support column names for min/max value") {

--- a/src/test/scala/com/target/data_validator/validator/RowBasedSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/RowBasedSpec.scala
@@ -121,7 +121,7 @@ class RowBasedSpec extends FunSpec with Matchers with TestingSparkSession {
 
   }
 
-  describe ("threshold parsing") {
+  describe ("threshold tests") {
     describe ("validate different way of specifying thresholds") {
       it ("absolute 10") {
         val sut = NullCheck("col", Some("10"))
@@ -196,6 +196,11 @@ class RowBasedSpec extends FunSpec with Matchers with TestingSparkSession {
       it ("10%") {
         val sut = NullCheck("col", Some("10%"))
         assert(sut.calcErrorCountThreshold(rowCount) == 1000)
+      }
+
+      it ("check for integer division") {
+        val sut = NullCheck("col", Some("10%"))
+        assert(sut.calcErrorCountThreshold(99) == 9) // scalastyle:ignore
       }
     }
   }

--- a/src/test/scala/com/target/data_validator/validator/RowBasedSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/RowBasedSpec.scala
@@ -133,9 +133,15 @@ class RowBasedSpec extends FunSpec with Matchers with TestingSparkSession {
         assert(!sut.configCheckThreshold)
       }
 
-      it ("100%") {
+      it ("10%") {
         val sut = NullCheck("col", Some("10%"))
         assert(!sut.configCheckThreshold)
+      }
+
+      it (" works with extra spacing before percentage sign") {
+        val sut = NullCheck("col", Some("10%"))
+        assert(!sut.configCheckThreshold)
+        assert(sut.calcErrorCountThreshold(100) == 10) // scalastyle:ignore
       }
 
       it("bad value") {
@@ -143,6 +149,36 @@ class RowBasedSpec extends FunSpec with Matchers with TestingSparkSession {
         assert(sut.configCheckThreshold)
         assert(sut.failed)
       }
+
+      it ("is negative") {
+        val sut = NullCheck("col", Some("-10"))
+        assert(sut.configCheckThreshold)
+        assert(sut.failed)
+      }
+
+      it ("is negative fraction") {
+        val sut = NullCheck("col", Some("-0.1"))
+        assert(sut.configCheckThreshold)
+        assert(sut.failed)
+      }
+      it ("is negative percent") {
+        val sut = NullCheck("col", Some("-10%"))
+        assert(sut.configCheckThreshold)
+        assert(sut.failed)
+      }
+
+      it ("negative percentage should be rejected") {
+        val sut = NullCheck("col", Some("-2.3 %"))
+        assert(sut.configCheckThreshold)
+        assert(sut.failed)
+      }
+
+      it ("multiple '%' should be rejected") {
+        val sut = NullCheck("col", Some("2.3 %%%"))
+        assert(sut.configCheckThreshold)
+        assert(sut.failed)
+      }
+
     }
 
     describe ("calMaxErrors()") {
@@ -157,7 +193,7 @@ class RowBasedSpec extends FunSpec with Matchers with TestingSparkSession {
         assert(sut.calcErrorCountThreshold(rowCount) == 1000)
       }
 
-      it ("100%") {
+      it ("10%") {
         val sut = NullCheck("col", Some("10%"))
         assert(sut.calcErrorCountThreshold(rowCount) == 1000)
       }

--- a/src/test/scala/com/target/data_validator/validator/StringLengthCheckSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/StringLengthCheckSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{FunSpec, Matchers}
 
 import scala.util.Random
 
-class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSession {
+class StringLengthCheckSpec extends FunSpec with Matchers with TestingSparkSession {
 
   val schema = StructType(
     List(
@@ -148,7 +148,7 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
         dict.add("threshold", threshold)
         val sut = StringLengthCheck("item", minValue, maxValue, Some("${threshold}"))
         assert(sut.substituteVariables(dict) == StringLengthCheck("item", minValue, maxValue,
-           Some("100"))) // scalastyle: ignore
+          Some("100"))) // scalastyle: ignore
         assert(!sut.failed)
       }
     }
@@ -264,7 +264,7 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
 
     describe("Basic String Length check") {
 
-      it ("String length check fails numErrorsToReport:1") {
+      it("String length check fails numErrorsToReport:1") {
         val dict = new VarSubstitution
         val df = mkDataFrame(spark, defData)
         val sut = StringLengthCheck("item", Some(Json.fromInt(5)), Some(Json.fromInt(6)), None) // scalastyle:ignore
@@ -279,15 +279,15 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
         // There are 2 invalid rows, and numErrorsToReport is
         // 1. So we need to check that exactly one of the 2 errors are present
         assert((sut.getEvents contains
-                ValidatorQuickCheckError(("item", "I") :: Nil, "I",
-                  "StringLengthCheck failed! item = I and ((length('item) < 5) || (length('item) > 6))")) ^
-               (sut.getEvents contains
-                 ValidatorQuickCheckError(("item", "") :: Nil, "",
-                   "StringLengthCheck failed! item =  and ((length('item) < 5) || (length('item) > 6))"))
-             )
+          ValidatorQuickCheckError(("item", "I") :: Nil, "I",
+            "StringLengthCheck failed! item = I and ((length('item) < 5) || (length('item) > 6))")) ^
+          (sut.getEvents contains
+            ValidatorQuickCheckError(("item", "") :: Nil, "",
+              "StringLengthCheck failed! item =  and ((length('item) < 5) || (length('item) > 6))"))
+        )
       }
 
-      it ("String length check fails numErrorsToReport:2") {
+      it("String length check fails numErrorsToReport:2") {
         val dict = new VarSubstitution
         val df = mkDataFrame(spark, defData)
         val sut = StringLengthCheck("item", Some(Json.fromInt(5)), Some(Json.fromInt(6)), None) // scalastyle:ignore
@@ -308,7 +308,7 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
             "StringLengthCheck failed! item =  and ((length('item) < 5) || (length('item) > 6))"))
       }
 
-      it ("String length check fails for minValue = maxValue and numErrorsToReport:3") {
+      it("String length check fails for minValue = maxValue and numErrorsToReport:3") {
         val dict = new VarSubstitution
         val df = mkDataFrame(spark, defData)
         val sut = StringLengthCheck("item", Some(Json.fromInt(5)), Some(Json.fromInt(5)), None) // scalastyle:ignore
@@ -333,7 +333,7 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
             "StringLengthCheck failed! item = Item23 and ((length('item) < 5) || (length('item) > 5))"))
       }
 
-      it ("String length check fails for only minValue specified and numErrorsToReport:2") {
+      it("String length check fails for only minValue specified and numErrorsToReport:2") {
         val dict = new VarSubstitution
         val df = mkDataFrame(spark, defData)
         val sut = StringLengthCheck("item", Some(Json.fromInt(5)), None, None) // scalastyle:ignore
@@ -354,7 +354,7 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
             "StringLengthCheck failed! item =  and (length('item) < 5)"))
       }
 
-      it ("String length check fails for only maxValue specified and numErrorsToReport:2") {
+      it("String length check fails for only maxValue specified and numErrorsToReport:2") {
         val dict = new VarSubstitution
         val df = mkDataFrame(spark, defData)
         val sut = StringLengthCheck("item", None, Some(Json.fromInt(2)), None) // scalastyle:ignore
@@ -375,7 +375,7 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
             "StringLengthCheck failed! item = Item23 and (length('item) > 2)"))
       }
 
-      it ("String length check passes for minValue and  maxValue specified") {
+      it("String length check passes for minValue and  maxValue specified") {
         val dict = new VarSubstitution
         val df = mkDataFrame(spark, defData)
         val sut = StringLengthCheck("item", Some(Json.fromInt(0)), Some(Json.fromInt(6)), None) // scalastyle:ignore
@@ -388,7 +388,7 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
           ValidatorCheckEvent(failure = false, "StringLengthCheck on column 'item'", 4, 0)) // scalastyle:ignore
       }
 
-      it ("String length check passes for only minValue specified") {
+      it("String length check passes for only minValue specified") {
         val dict = new VarSubstitution
         val df = mkDataFrame(spark, defData)
         val sut = StringLengthCheck("item", Some(Json.fromInt(0)), None, None) // scalastyle:ignore
@@ -401,7 +401,7 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
           ValidatorCheckEvent(failure = false, "StringLengthCheck on column 'item'", 4, 0)) // scalastyle:ignore
       }
 
-      it ("String length check passes for only maxValue specified") {
+      it("String length check passes for only maxValue specified") {
         val dict = new VarSubstitution
         val df = mkDataFrame(spark, defData)
         val sut = StringLengthCheck("item", None, Some(Json.fromInt(6)), None) // scalastyle:ignore

--- a/src/test/scala/com/target/data_validator/validator/StringLengthCheckSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/StringLengthCheckSpec.scala
@@ -75,7 +75,8 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
           None
         )
         assert(sut.configCheck(df))
-        assert(sut.getEvents contains ValidatorError("Data type of column 'baseprice' must be String, but was found to be DoubleType"))
+        assert(sut.getEvents contains
+          ValidatorError("Data type of column 'baseprice' must be String, but was found to be DoubleType"))
         assert(sut.failed)
       }
 
@@ -121,7 +122,8 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
         val dict = new VarSubstitution
         dict.addString("maxValue", "10")
         val sut = StringLengthCheck("item", None, Some(Json.fromString("${maxValue}")), None)
-        assert(sut.substituteVariables(dict) == StringLengthCheck("item", None, Some(Json.fromInt(10)), None))
+        assert(sut.substituteVariables(dict) ==
+          StringLengthCheck("item", None, Some(Json.fromInt(10)), None)) // scalastyle:ignore
         assert(!sut.failed)
       }
 
@@ -172,7 +174,7 @@ class StringLengthCheckSpec  extends FunSpec with Matchers with TestingSparkSess
         val sut = StringLengthCheck("item", Some(Json.fromInt(1)), Some(Json.fromInt(10)), None) // scalastyle:ignore
         assert(sut.colTest(schema, dict).sql ==
           Or(LessThan(Length(UnresolvedAttribute("item")), Literal.create(1, IntegerType)),
-            GreaterThan(Length(UnresolvedAttribute("item")), Literal.create(10, IntegerType))).sql)
+            GreaterThan(Length(UnresolvedAttribute("item")), Literal.create(10, IntegerType))).sql) // scalastyle:ignore
       }
 
     }

--- a/src/test/scala/com/target/data_validator/validator/TestHelpersSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/TestHelpersSpec.scala
@@ -2,8 +2,9 @@ package com.target.data_validator.validator
 
 import com.target.TestingSparkSession
 import com.target.data_validator.TestHelpers._
+import io.circe.Json
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types._
 import org.scalatest.{FunSpec, Matchers}
 
 class TestHelpersSpec  extends FunSpec with Matchers with TestingSparkSession {
@@ -23,20 +24,33 @@ class TestHelpersSpec  extends FunSpec with Matchers with TestingSparkSession {
       StructField("instock", BooleanType))
   )
 
-
   describe("parseYml") {
-
+    it ("parses simple yml") {
+      val sut = parseYaml(
+        """
+          |double: 2.01
+          |int: 10293
+          |string: foo
+          |array:
+          | - one
+          | - two
+          | - three
+        """.stripMargin)
+      assert(sut == Json.obj(
+        ("double", Json.fromDouble(2.01).get),
+        ("int", Json.fromInt(10293)), // scalastyle:ignore
+        ("string", Json.fromString("foo")),
+        ("array", Json.arr(Seq("one", "two", "three").map(Json.fromString): _*))
+      ))
+    }
   }
 
   describe("mkDict") {
     it("simple case") {
-      // val sut = mkDict("key"->"value")
-      // assert(sut.dict == Map("key" -> "value"))
+      val sut = mkDict("key"->"value")
+      assert(sut.dict("key") ==  Json.fromString("value"))
     }
   }
-
-
-  // guessType
 
   describe("guessType") {
     it("double") {

--- a/src/test/scala/com/target/data_validator/validator/TestHelpersSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/TestHelpersSpec.scala
@@ -1,0 +1,82 @@
+package com.target.data_validator.validator
+
+import com.target.TestingSparkSession
+import com.target.data_validator.TestHelpers._
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.{BooleanType, DoubleType, IntegerType, StringType, StructField, StructType}
+import org.scalatest.{FunSpec, Matchers}
+
+class TestHelpersSpec  extends FunSpec with Matchers with TestingSparkSession {
+
+
+  val data = List(
+    "item"->List("item1", "item2", "item3", null), // scalastyle:ignore
+    "price" -> List(1.99, 2.99, 3.99, 0.0),
+    "count" -> List(1, 2, 3, 0),
+    "instock" -> List(true, false, true, false)
+  )
+
+  val expectedSchema = StructType(
+    List(StructField("item", StringType),
+      StructField("price", DoubleType),
+      StructField("count", IntegerType),
+      StructField("instock", BooleanType))
+  )
+
+
+  describe("parseYml") {
+
+  }
+
+  describe("mkDict") {
+    it("simple case") {
+      // val sut = mkDict("key"->"value")
+      // assert(sut.dict == Map("key" -> "value"))
+    }
+  }
+
+
+  // guessType
+
+  describe("guessType") {
+    it("double") {
+      assert(guessType(1.99) == DoubleType) // scalastyle: ignore
+    }
+
+    it("int") {
+      assert(guessType(1) == IntegerType) // scalastyle: ignore
+    }
+
+    it("string") {
+      assert(guessType("string") == StringType)
+    }
+
+    it("boolean") {
+      assert(guessType(true) == BooleanType)
+    }
+
+  }
+
+  describe("mkSchema") {
+    it("simple") {
+      assert(mkSchema(data: _*) == expectedSchema)
+    }
+  }
+
+  describe ("mkRows") {
+    assert(mkRows(data: _*) == List(Row("item1", 1.99, 1, true),
+      Row("item2", 2.99, 2, false),
+      Row("item3", 3.99, 3, true),
+      Row(null, 0.0, 0, false))) // scalastyle:ignore
+  }
+  // mkDf
+
+  describe("mkDf") {
+
+  }
+
+
+
+
+
+}


### PR DESCRIPTION
This pr adds thresholds to RowBased checks (negativeCheck, nullCheck, rangeCheck) 
Thresholds lets the user define an acceptable error threshold that they can tolerate. 
Currently if you have a single error in a Billion row table, the check will fail. 
A threshold can be represented as a number of rows, or a percentage of the total number of rows processed. 

~~~
type: negativeCheck
column: price
threshold: 2.3%
~~~
