### PR TITLE
Logs email failures with what addresses succeeded, failed, and failed to parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ throughout the program.
 | `cc` | Array[String] | No | Optional list of email addresses to send message to via `cc` field in message.
 | `bcc` | Array[String] | No | Optional list of email addresses to send message to via `bcc` field in message.
 
+Note that Data Validator only sends email on _failure_ by default. To send email even on successful runs,
+pass `--emailOnPass true` to the command line.
 
 #### Defining Variables
 

--- a/src/main/scala/com/target/data_validator/Emailer.scala
+++ b/src/main/scala/com/target/data_validator/Emailer.scala
@@ -117,7 +117,7 @@ object Emailer extends LazyLogging {
     }
     catch {
       case sfe: SendFailedException =>
-        logger.warn(s"Failure to send email #$id: $sfe")
+        logger.warn(s"Failure to send email #$id: ${sfe.getMessage}")
         if (sfe.getValidSentAddresses.nonEmpty) {
           logger.warn(s"Email #$id was sent to [${sfe.getValidSentAddresses.mkString(", ")}]")
         }

--- a/src/main/scala/com/target/data_validator/Emailer.scala
+++ b/src/main/scala/com/target/data_validator/Emailer.scala
@@ -112,7 +112,7 @@ object Emailer extends LazyLogging {
     try {
       logger.info(s"Sending email #$id [${message.getSubject}] to [${message.getAllRecipients.mkString(", ")}]")
       Transport.send(message)
-      logger.info(s"Email #$id sent totally successfully.")
+      logger.info(s"Email #$id sent successfully to all recipients.")
       false
     }
     catch {

--- a/src/main/scala/com/target/data_validator/Emailer.scala
+++ b/src/main/scala/com/target/data_validator/Emailer.scala
@@ -114,10 +114,20 @@ object Emailer extends LazyLogging {
     }
     catch {
       case sfe: SendFailedException =>
-        logger.error(s"Failed to send message, $sfe")
+        logger.error(s"Failure to send email: $sfe")
+        if (sfe.getValidSentAddresses.nonEmpty) {
+          logger.error(s"Email sent to ${sfe.getValidSentAddresses.mkString(",")}")
+        }
+        if (sfe.getValidUnsentAddresses.nonEmpty) {
+          logger.error(s"Email not sent to ${sfe.getValidUnsentAddresses.mkString(",")}")
+        }
+        if (sfe.getInvalidAddresses.nonEmpty) {
+          logger.error(s"Invalid addresses: ${sfe.getInvalidAddresses.mkString(",")}")
+        }
+
         true
       case me: MessagingException =>
-        logger.error(s"MessingException while trying to send email, $me")
+        logger.error(s"Failure to send email: $me")
         true
     }
   }


### PR DESCRIPTION
`javax.mail.SendFailedException` doesn't include enough context in its simple toString implementation, so I've added that context available in the exception to the log when DV encounters that exception while sending email.