### PR TITLE
Tweaks the colstats description

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,9 +334,9 @@ This check generates column statistics about the specified column.
 |-------------|-------------|--------------------------------------------|
 | `column`    | String      | The column on which to collect statistics. |
 
-These values will appear in the check's JSON summary when using the JSON report output mode:
+These keys and their corresponding values will appear in the check's JSON summary when using the JSON report output mode:
 
-| Arg         | Type        | Description                                                                                                             |
+| Key         | Type        | Description                                                                                                             |
 |-------------|-------------|-------------------------------------------------------------------------------------------------------------------------|
 | `count`     | Integer     | Count of non-null entries in the `column`.                                                                              |
 | `mean`      | Double      | Mean/Average of the values in the `column`.                                                                             |


### PR DESCRIPTION
The word "value" and the structure of the table made me think that that list of statistical measures needed to be specified in the config. I had to read it a couple times to realize that this is just informational about the things that colstats will output. Suggest a quick tweak to the language to clarify this.