### PR TITLE
Add support for Hive Warehouse Connector for Spark / Hive3 Integration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,12 @@ enablePlugins(BuildInfoPlugin)
 buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion)
 buildInfoPackage := "com.target.data_validator"
 
+resolvers += "Hortonworks Repo" at "https://repo.hortonworks.com/content/repositories/releases"
+
+// https://stackoverflow.com/questions/21515325/add-a-compile-time-only-dependency-in-sbt
+val CompileOnly = config("compileonly").hide
+ivyConfigurations += CompileOnly
+
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.8.0",
   "com.github.scopt" %% "scopt" % "3.7.0",
@@ -43,11 +49,16 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-hive" % sparkVersion % Provided,
+  "com.hortonworks.hive" %% "hive-warehouse-connector" % "1.0.0.3.1.0.53-1" % "compileonly",
 
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "junit" % "junit" % "4.12" % Test,
   "com.novocode" % "junit-interface" % "0.11" % Test exclude("junit", "junit-dep")
 )
+
+// appending everything from 'compileonly' to unmanagedClasspath
+unmanagedClasspath in Compile ++=
+  update.value.select(configurationFilter("compileonly"))
 
 fork in Test := true
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled")

--- a/src/main/scala/com/target/data_validator/ValidatorTable.scala
+++ b/src/main/scala/com/target/data_validator/ValidatorTable.scala
@@ -209,6 +209,13 @@ case class ValidatorHiveTable(
   s"HiveTable:`$db.$table`" + condition.map(c => s" with condition($c)").getOrElse("")
 ) {
 
+  override def open(session: SparkSession): Try[DataFrame] = {
+    useHWC match {
+      case Some(x) if x => getDF(session)
+      case _ => super.open(session)
+    }
+  }
+
   override def getDF(session: SparkSession): Try[DataFrame] = {
     logger.info(s"Opening table: $db.$table")
     useHWC match {

--- a/src/test/scala/com/target/data_validator/ConfigParserSpec.scala
+++ b/src/test/scala/com/target/data_validator/ConfigParserSpec.scala
@@ -26,6 +26,7 @@ class ConfigParserSpec extends FunSpec with BeforeAndAfterAll {
       ValidatorHiveTable(
         "foo",
         "bar",
+        None,
         Some(List("one", "two")),
         None,
         List(MinNumRows(10294), NullCheck("mdse_item_i", None)) // scalastyle:ignore magic.number

--- a/src/test/scala/com/target/data_validator/ConfigVarSubSpec.scala
+++ b/src/test/scala/com/target/data_validator/ConfigVarSubSpec.scala
@@ -24,13 +24,14 @@ class ConfigVarSubSpec extends FunSpec with Matchers with TestingSparkSession {
         val sut = ValidatorHiveTable(
           "database$one",
           "table$two",
+          None,
           Some(List("Col$three", "Col$four")),
           Some("$five == $six"),
           List.empty
         )
         assert(
           sut.substituteVariables(dict) ==
-            ValidatorHiveTable("database1", "table2", Some(List("Col3", "Col4")), Some("5 == 6"), List.empty)
+            ValidatorHiveTable("database1", "table2", None, Some(List("Col3", "Col4")), Some("5 == 6"), List.empty)
         )
       }
 

--- a/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
+++ b/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
@@ -73,7 +73,7 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
       describe("should work for all part of HiveTable") {
 
         it("variable substitution should work for database") {
-          val vt = ValidatorHiveTable("$db", "table", None, None, List.empty)
+          val vt = ValidatorHiveTable("$db", "table", None, None, None, List.empty)
           val dict = mkDict(("db", "myDatabase"))
           val sut = vt.substituteVariables(dict)
           assert(sut == vt.copy(db = "myDatabase"))
@@ -81,7 +81,7 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
         }
 
         it("variable substitution should work for table") {
-          val vt = ValidatorHiveTable("database", "$table", None, None, List.empty)
+          val vt = ValidatorHiveTable("database", "$table", None, None, None, List.empty)
           val dict = mkDict(("table", "myTable"))
           val sut = vt.substituteVariables(dict)
           assert(sut == vt.copy(table = "myTable"))
@@ -89,7 +89,7 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
         }
 
         it ("keyColumn") {
-          val vt = ValidatorHiveTable("database", "table", Some(List("$key1", "$key2")), None, List.empty)
+          val vt = ValidatorHiveTable("database", "table", None, Some(List("$key1", "$key2")), None, List.empty)
           val dict = mkDict(("key1", "col1"), ("key2", "col2"))
           val sut = vt.substituteVariables(dict)
           assert(sut == vt.copy(keyColumns = Some(List("col1", "col2"))))
@@ -98,7 +98,7 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
         }
 
         it("condition") {
-          val vt = ValidatorHiveTable("database", "table", None, Some("end_d < '$end_date'"), List.empty)
+          val vt = ValidatorHiveTable("database", "table", None, None, Some("end_d < '$end_date'"), List.empty)
           val dict = mkDict(("end_date", "2018-11-26"))
           val sut = vt.substituteVariables(dict)
           assert(sut == vt.copy(condition = Some("end_d < '2018-11-26'")))
@@ -106,7 +106,7 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
         }
 
         it("checks") {
-          val vt = ValidatorHiveTable("database", "table", None, None, List(NullCheck("${nullCol1}", None)))
+          val vt = ValidatorHiveTable("database", "table", None, None, None, List(NullCheck("${nullCol1}", None)))
           val dict = mkDict(("nullCol1", "nc1"), ("nullCol2", "nc2"))
           val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorHiveTable]
           assert(sut == vt.copy(checks = List(NullCheck("nc1", None))))

--- a/src/test/scala/com/target/data_validator/validator/ConfigVarSpec.scala
+++ b/src/test/scala/com/target/data_validator/validator/ConfigVarSpec.scala
@@ -154,23 +154,23 @@ class ConfigVarSpec extends FunSpec with Matchers with TestingSparkSession {
       it("from Json snippet") {
         val json: Json = parse("""{ "name":"foo", "sql":"select 1"}""").getOrElse(Json.Null)
         val sut = json.as[ConfigVar]
-        assert(sut == Right(NameSql("foo", "select 1")))
+        assert(sut == Right(NameSql("foo", None, "select 1")))
       }
 
       it("addEntry works as expected") {
-        val sut = NameSql("one", "select 1")
+        val sut = NameSql("one", None, "select 1")
         val varSub = new VarSubstitution
         assert(!sut.addEntry(spark, varSub))
         assert(varSub.dict("one") == Json.fromInt(1))
       }
 
       it("asJson works") {
-        val sut = NameSql("one", "select 1")
-        assert(sut.asJson.noSpaces == """{"name":"one","sql":"select 1"}""")
+        val sut = NameSql("one", None, "select 1")
+        assert(sut.asJson.noSpaces == """{"name":"one","useHWC":null,"sql":"select 1"}""")
       }
 
       it("bad sql works as expected") {
-        val sut = NameSql("one", "bad sql")
+        val sut = NameSql("one", None, "bad sql")
         val varSub = new VarSubstitution
         assert(sut.addEntry(spark, varSub))
       }
@@ -179,7 +179,7 @@ class ConfigVarSpec extends FunSpec with Matchers with TestingSparkSession {
         val schema = StructType(List(StructField("data", IntegerType)))
         val df = spark.createDataFrame(sc.parallelize(List(Row(10))), schema) // scalastyle:ignore
         df.createTempView("MyTable")
-        val sut = NameSql("one", "select data from MyTable where data < 10")
+        val sut = NameSql("one", None, "select data from MyTable where data < 10")
         val varSub = new VarSubstitution
         assert(sut.addEntry(spark, varSub))
       }


### PR DESCRIPTION
Must specify `useHWC: true` in the configuration (from example in [README](https://github.com/target/data-validator#example-config)):

```yaml
tables:
  - db: census_income
    table: adult
    useHWC: true
    keyColumns:
      - age
      - occupation
    condition: educationNum >= 5
    checks:
      # rowCount - checks if the number of rows is at least minRows
      - type: rowCount
        minNumRows: 50000
```

User must specify appropriate [configuration](https://docs.cloudera.com/HDPDocuments/HDP3/HDP-3.1.4/integrating-hive/content/hive_configure_a_spark_hive_connection.html) options for their system.  Additionally, an appropriate [hive-warehouse-connector jar](https://docs.cloudera.com/HDPDocuments/HDP3/HDP-3.1.4/integrating-hive/content/hive_submit_a_hivewarehouseconnector_app.html) must be supplied at runtime.