### PR TITLE
Extracts CLI parsing from Main, writes a test for edge case

### DIFF
--- a/src/main/scala/com/target/data_validator/CliOptionParser.scala
+++ b/src/main/scala/com/target/data_validator/CliOptionParser.scala
@@ -1,0 +1,50 @@
+package com.target.data_validator
+
+import scopt.OptionParser
+
+case class CmdLineOptions(
+  configFilename: String = "",
+  verbose: Boolean = false,
+  jsonReport: Option[String] = None,
+  htmlReport: Option[String] = None,
+  exitErrorOnFail: Boolean = true,
+  vars: Map[String, String] = Map(),
+  emailOnPass: Boolean = false
+)
+
+object CliOptionParser {
+
+  def parser: OptionParser[CmdLineOptions] = new OptionParser[CmdLineOptions]("data-validator") {
+    head(BuildInfo.name, "v" + BuildInfo.version)
+
+    version("version")
+
+    opt[Unit]("verbose").action((_, c) =>
+      c.copy(verbose = true)).text("Print additional debug output.")
+
+    opt[String]("config").action((fn, c) =>
+      c.copy(configFilename = fn))
+      .text(
+        "required validator config .yaml filename, " +
+          "prefix w/ 'classpath:' to load configuration from JVM classpath/resources, " +
+          "ex. '--config classpath:/config.yaml'")
+
+    opt[String]("jsonReport").action((fn, c) =>
+      c.copy(jsonReport = Some(fn))).text("optional JSON report filename")
+
+    opt[String]("htmlReport").action((fn, c) =>
+      c.copy(htmlReport = Some(fn))).text("optional HTML report filename")
+
+    opt[Map[String, String]]("vars").valueName("k1=v1,k2=v2...").action((x, c) =>
+      c.copy(vars = x)).text("other arguments")
+
+    opt[Boolean]("exitErrorOnFail").valueName("true|false").action((x, c) => c.copy(exitErrorOnFail = x))
+      .text("optional when true, if validator fails, call System.exit(-1) " +
+        "Defaults to True, but will change to False in future version.")
+
+    opt[Boolean]("emailOnPass").valueName("true|false").action((x, c) => c.copy(emailOnPass = x))
+      .text("optional when true, sends email on validation success. Default: false")
+
+    help("help").text("Show this help message and exit.")
+  }
+}

--- a/src/main/scala/com/target/data_validator/CliOptionParser.scala
+++ b/src/main/scala/com/target/data_validator/CliOptionParser.scala
@@ -2,7 +2,7 @@ package com.target.data_validator
 
 import scopt.OptionParser
 
-case class CmdLineOptions(
+case class CliOptions(
   configFilename: String = "",
   verbose: Boolean = false,
   jsonReport: Option[String] = None,
@@ -14,7 +14,7 @@ case class CmdLineOptions(
 
 object CliOptionParser {
 
-  def parser: OptionParser[CmdLineOptions] = new OptionParser[CmdLineOptions]("data-validator") {
+  def parser: OptionParser[CliOptions] = new OptionParser[CliOptions]("data-validator") {
     head(BuildInfo.name, "v" + BuildInfo.version)
 
     version("version")

--- a/src/main/scala/com/target/data_validator/Main.scala
+++ b/src/main/scala/com/target/data_validator/Main.scala
@@ -9,16 +9,6 @@ import scopt.OptionParser
 
 object Main extends LazyLogging with EventLog {
 
-  case class CmdLineOptions(
-    configFilename: String = "",
-    verbose: Boolean = false,
-    jsonReport: Option[String] = None,
-    htmlReport: Option[String] = None,
-    exitErrorOnFail: Boolean = true,
-    vars: Map[String, String] = Map(),
-    emailOnPass: Boolean = false
-  )
-
   def loadConfigRun(mainConfig: CmdLineOptions): (Boolean, Boolean) =
     ConfigParser.parseFile(mainConfig.configFilename, mainConfig.vars) match {
       case Left(error) =>
@@ -88,7 +78,7 @@ object Main extends LazyLogging with EventLog {
   def runChecks(mainConfig: CmdLineOptions, origConfig: ValidatorConfig): (Boolean, Boolean) = {
     val varSub = new VarSubstitution
 
-    implicit val spark = SparkSession.builder.appName("data-validator").enableHiveSupport().getOrCreate()
+    implicit val spark: SparkSession = SparkSession.builder.appName("data-validator").enableHiveSupport().getOrCreate()
 
     if (mainConfig.verbose) {
       logger.info("Verbose Flag detected")
@@ -130,39 +120,7 @@ object Main extends LazyLogging with EventLog {
   def main (args: Array[String]): Unit = {
     configLogging()
 
-    val parser = new OptionParser[CmdLineOptions]("data-validator") {
-      head(BuildInfo.name, "v" + BuildInfo.version)
-
-      version("version")
-
-      opt[Unit]("verbose").action((_, c) =>
-        c.copy(verbose = true)).text("Print additional debug output.")
-
-      opt[String]("config").action((fn, c) =>
-        c.copy(configFilename = fn))
-        .text(
-          "required validator config .yaml filename, " +
-          "prefix w/ 'classpath:' to load configuration from JVM classpath/resources, " +
-          "ex. '--config classpath:/config.yaml'")
-
-      opt[String]("jsonReport").action((fn, c) =>
-        c.copy(jsonReport = Some(fn))).text("optional JSON report filename")
-
-      opt[String]("htmlReport").action((fn, c) =>
-        c.copy(htmlReport = Some(fn))).text("optional HTML report filename")
-
-      opt[Map[String, String]]("vars").valueName("k1=v1,k2=v2...").action((x, c) =>
-        c.copy(vars = x)).text("other arguments")
-
-      opt[Boolean]("exitErrorOnFail").valueName("true|false").action((x, c) => c.copy(exitErrorOnFail = x))
-        .text("optional when true, if validator fails, call System.exit(-1) " +
-          "Defaults to True, but will change to False in future version.")
-
-      opt[Boolean]("emailOnPass").valueName("true|false").action((x, c) => c.copy(emailOnPass = x))
-        .text("optional when true, sends email on validation success. Default: false")
-
-      help("help").text("Show this help message and exit.")
-    }
+    val parser = CliOptionParser.parser
 
     logger.info("Data Validator")
 

--- a/src/main/scala/com/target/data_validator/Reports.scala
+++ b/src/main/scala/com/target/data_validator/Reports.scala
@@ -1,6 +1,5 @@
 package com.target.data_validator
 
-import com.target.data_validator.Main.CmdLineOptions
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.SparkSession
 

--- a/src/main/scala/com/target/data_validator/Reports.scala
+++ b/src/main/scala/com/target/data_validator/Reports.scala
@@ -6,9 +6,9 @@ import org.apache.spark.sql.SparkSession
 object Reports extends LazyLogging with EventLog {
 
   def emailReport(
-    mainConfig: CmdLineOptions,
-    config: ValidatorConfig,
-    varSub: VarSubstitution
+                   mainConfig: CliOptions,
+                   config: ValidatorConfig,
+                   varSub: VarSubstitution
   )(implicit spark: SparkSession): Unit = {
     if (mainConfig.htmlReport.isDefined || config.email.isDefined) {
       val htmlReport = config.generateHTMLReport()
@@ -26,9 +26,9 @@ object Reports extends LazyLogging with EventLog {
   }
 
   def jsonReport(
-    mainConfig: CmdLineOptions,
-    config: ValidatorConfig,
-    varSub: VarSubstitution
+                  mainConfig: CliOptions,
+                  config: ValidatorConfig,
+                  varSub: VarSubstitution
   )(implicit spark: SparkSession): Unit = {
     if (config.outputs.isDefined || mainConfig.jsonReport.isDefined) {
       val jsonReport = config.genJsonReport(varSub)

--- a/src/test/scala/com/target/data_validator/CliOptionParserSpec.scala
+++ b/src/test/scala/com/target/data_validator/CliOptionParserSpec.scala
@@ -8,7 +8,7 @@ class CliOptionParserSpec extends FunSpec with Matchers {
     describe("parsing") {
       it("does not handle var option values with commas") {
         val args = Array("--vars", "keyA=value1,value2,keyB=value3")
-        CliOptionParser.parser.parse(args, CmdLineOptions()) should be(None)
+        CliOptionParser.parser.parse(args, CliOptions()) should be(None)
       }
     }
   }

--- a/src/test/scala/com/target/data_validator/CliOptionParserSpec.scala
+++ b/src/test/scala/com/target/data_validator/CliOptionParserSpec.scala
@@ -1,0 +1,15 @@
+package com.target.data_validator
+
+import org.scalatest.{FunSpec, Matchers}
+
+class CliOptionParserSpec extends FunSpec with Matchers {
+
+  describe("CliOptionParser") {
+    describe("parsing") {
+      it("does not handle var option values with commas") {
+        val args = Array("--vars", "keyA=value1,value2,keyB=value3")
+        CliOptionParser.parser.parse(args, CmdLineOptions()) should be(None)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Apparently, scopt doesn't provide a way to escape commas in
a comma-separated key-value list option.

https://github.com/scopt/scopt/issues/111

This test documents that and enables us to test fixes for it.