### PR TITLE
Avoid test failure from envvar missing in some environments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,6 +53,10 @@ libraryDependencies ++= Seq(
 Test / fork := true
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled")
 Test / parallelExecution := false
+// required for unit tests, but not set in some environments
+Test / envVars ++= Map("JAVA_HOME" ->
+  Option(System.getenv("JAVA_HOME"))
+    .getOrElse(System.getProperty("java.home")))
 
 assembly / mainClass := Some("com.target.data_validator.Main")
 


### PR DESCRIPTION
Set JAVA_HOME variable for test scope because in some OSes, it's not set by default. Notably, Ubuntu doesn't set the envvar in user profiles when using tooling such as `update-java-alternatives`. This avoids a spurious test failure becaus of the assumption that this envvar would always be set. It was, when all dev was done on Macs ;-)

Fixes #66