### PR TITLE
Use GHA release.published action instead of push.tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,19 +1,39 @@
 name: Release
 
 on:
-  push:
-    tags: "[1-9]+.[0-9]+.[0-9]+"
-    branches: master
+  release:
+    types: [published]
+  #push:
+  #  tags: "[1-9]+.[0-9]+.[0-9]+"
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  build:
-    uses: target/data-validator/.github/workflows/ci.yaml@main
   deploy:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v2
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.8
+
+      - name: Cache sbt
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.sbt
+            ~/.ivy2/cache
+            ~/.coursier/cache/v1
+            ~/.cache/coursier/v1
+            ~/AppData/Local/Coursier/Cache/v1
+            ~/Library/Caches/Coursier/v1
+          key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
+      
       # uses sbt-github-packages, see build.sbt
-      - run: bin/sbt publish
+      - name: Publish with SBT
+        run: bin/sbt publish


### PR DESCRIPTION
While it was in examples, I can't actually seem to find push.tags in the documentation…?