### PR TITLE
Adds a custom format loader enabling DataSource plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ To validate an `.parquet` file, specify `parquetFile` and the path to the file, 
   checks:
 ```
 
-#### Core `spark.read` fluent API
+#### Core `spark.read` fluent API specified format loader
 
 To validate data loadable by the Spark DataFrameReader Fluent API, use something like this:
 
@@ -240,8 +240,7 @@ To validate data loadable by the Spark DataFrameReader Fluent API, use something
   format: llama
   # You can also pass any valid options
   options:
-    key: value
-    user: 
+    maxMemory: 8G
   # This is a string passed to DataFrameReader.load(String)
   # If omitted, then DV will call DataFrameReader.load() without parameters.
   # The DataSource that Spark loads is expected to know how to handle this.
@@ -252,6 +251,15 @@ To validate data loadable by the Spark DataFrameReader Fluent API, use something
     - col2
   condition: "col1 < 100"
   checks:
+```
+
+Under the hood the above would be like loaded a DataFrame with:
+
+```scala
+spark.read
+  .format("llama")
+  .option("maxMemory", "8G")
+  .load("/path/to/something/camelid.llama")
 ```
 
 ### Validators

--- a/README.md
+++ b/README.md
@@ -241,11 +241,11 @@ To validate data loadable by the Spark DataFrameReader Fluent API, use something
   # You can also pass any valid options
   options:
     maxMemory: 8G
-  # This is a string passed to DataFrameReader.load(String)
+  # This is a string passed to the varargs version of DataFrameReader.load(String*)
   # If omitted, then DV will call DataFrameReader.load() without parameters.
   # The DataSource that Spark loads is expected to know how to handle this.
-  # This only handles a single string value, not a list.
-  loadData: /path/to/something/camelid.llama
+  loadData:
+    - /path/to/something/camelid.llama
   keyColumns:
     - col1
     - col2

--- a/README.md
+++ b/README.md
@@ -79,26 +79,26 @@ quoting the variables in the config.
 The first section is the global settings that are used
 throughout the program.
 
-| Variable | Type | Required | Description
-|:---|:---|:---|:---:
-| `numKeyCols` | Int | Yes | The number of columns from the table schema to use to uniquely identify a row in the table.
-| `numErrorsToReport` | Int | Yes | The number of detailed errors to include in Validator Report.
-| `detailedErrors` | Boolean | Yes | If a check fails, run a second pass and gather `numErrorToReport` examples of failure.
-| `email` |EmailConfig|No| See [Email Config](#email-config).
-| `vars` | Map | No | A map of (key, value) pairs used for variable substitution in `tables` config. See next section.
-| `outputs`| Array | No | Describes where to send `.json` report. See [Validator Output](#validator-output).
-| `tables` | List | Yes | List of table sources used to load tables to validate.
+| Variable            | Type        | Required |                                           Description                                            |
+|:--------------------|:------------|:---------|:------------------------------------------------------------------------------------------------:|
+| `numKeyCols`        | Int         | Yes      |   The number of columns from the table schema to use to uniquely identify a row in the table.    |
+| `numErrorsToReport` | Int         | Yes      |                  The number of detailed errors to include in Validator Report.                   |
+| `detailedErrors`    | Boolean     | Yes      |      If a check fails, run a second pass and gather `numErrorToReport` examples of failure.      |
+| `email`             | EmailConfig | No       |                                See [Email Config](#email-config).                                |
+| `vars`              | Map         | No       | A map of (key, value) pairs used for variable substitution in `tables` config. See next section. |
+| `outputs`           | Array       | No       |        Describes where to send `.json` report. See [Validator Output](#validator-output).        |
+| `tables`            | List        | Yes      |                      List of table sources used to load tables to validate.                      |
 
 #### Email Config
 
-| Variable | Type | Required | Description |
-|:---|:---|:---|:---:
-| `smtpHost` | String | Yes | The smtp host to send email message through.
-| `subject` | String | Yes | Subject for email message.
-| `from` | String | Yes | Email address to appear in from part of message.
-| `to` | Array[String] | Yes | Must specify at least one email address to send the email report to.
-| `cc` | Array[String] | No | Optional list of email addresses to send message to via `cc` field in message.
-| `bcc` | Array[String] | No | Optional list of email addresses to send message to via `bcc` field in message.
+| Variable   | Type          | Required |                                   Description                                   |
+|:-----------|:--------------|:---------|:-------------------------------------------------------------------------------:|
+| `smtpHost` | String        | Yes      |                  The smtp host to send email message through.                   |
+| `subject`  | String        | Yes      |                           Subject for email message.                            |
+| `from`     | String        | Yes      |                Email address to appear in from part of message.                 |
+| `to`       | Array[String] | Yes      |      Must specify at least one email address to send the email report to.       |
+| `cc`       | Array[String] | No       | Optional list of email addresses to send message to via `cc` field in message.  |
+| `bcc`      | Array[String] | No       | Optional list of email addresses to send message to via `bcc` field in message. |
 
 Note that Data Validator only sends email on _failure_ by default. To send email even on successful runs,
 pass `--emailOnPass true` to the command line.
@@ -254,40 +254,40 @@ Currently supported validators are listed below:
 
 Takes 2 parameters, the column name and a `value`. The check will fail if `max(column)` is **not equal** to the value.
 
-| Arg | Type | Description |
-|-----|------|-------------|
-| `column` | String | Column within table to find the max from.
-| `value`  | \*     | The column max should equal this value or the check will fail.  **Note:** The type of the value should match the type of the column. If the column is a `NumericType`, the value cannot be a `String`.
+| Arg      | Type   | Description                                                                                                                                                                                            |
+|----------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `column` | String | Column within table to find the max from.                                                                                                                                                              |
+| `value`  | \*     | The column max should equal this value or the check will fail.  **Note:** The type of the value should match the type of the column. If the column is a `NumericType`, the value cannot be a `String`. |
 
 #### `negativeCheck`
 
 Takes a single parameter, the column name to check. The validator will fail if any rows with that column are negative.
 
-| Arg | Type | Description |
-|-----|------|-------------|
-| `column` | String | Table column to be checked for negative values.  If it contains a `null` validator will fail.  **Note:** Column must be of a `NumericType` or the check will fail during the config check.
-| `threshold` | String | See above description of threshold.
+| Arg         | Type   | Description                                                                                                                                                                                |
+|-------------|--------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `column`    | String | Table column to be checked for negative values.  If it contains a `null` validator will fail.  **Note:** Column must be of a `NumericType` or the check will fail during the config check. |
+| `threshold` | String | See above description of threshold.                                                                                                                                                        |
 
 #### `nullCheck`
 
 Takes a single parameter, the column name to check. The validator will fail if any rows with that column are `null`.
 
-| Arg | Type | Description |
-|-----|------|-------------|
-| `column` | String | Table column to be checked for `null`.  If it contains a `null` validator will fail.
-| `threshold` | String | See above description of threshold.
+| Arg         | Type   | Description                                                                          |
+|-------------|--------|--------------------------------------------------------------------------------------|
+| `column`    | String | Table column to be checked for `null`.  If it contains a `null` validator will fail. |
+| `threshold` | String | See above description of threshold.                                                  |
 
 #### `rangeCheck`
 
 Takes 2 - 4 parameters, described below. If the value in the column doesn't fall within the range specified by (`minValue`, `maxValue`) the check will fail.
 
-| Arg | Type | Description |
-|-----|------|-------------|
-| `column` | String | Table column to be checked.
-| `minValue` | \* | lower bound of the range, or other column in table. Type depends on the type of the `column`.
-| `maxValue` | \* | upper bound of the range, or other column in table. Type depends on the type of the `column`.
-| `inclusive` | Boolean | Include `minValue` and `maxValue` as part of the range.
-| `threshold` | String | See above description of threshold.
+| Arg         | Type    | Description                                                                                   |
+|-------------|---------|-----------------------------------------------------------------------------------------------|
+| `column`    | String  | Table column to be checked.                                                                   |
+| `minValue`  | \*      | lower bound of the range, or other column in table. Type depends on the type of the `column`. |
+| `maxValue`  | \*      | upper bound of the range, or other column in table. Type depends on the type of the `column`. |
+| `inclusive` | Boolean | Include `minValue` and `maxValue` as part of the range.                                       |
+| `threshold` | String  | See above description of threshold.                                                           |
 
 **Note:** To specify another column in the table, you must prefix the column name with a **`** (backtick).
 
@@ -296,12 +296,12 @@ Takes 2 - 4 parameters, described below. If the value in the column doesn't fall
 Takes 2 to 4 parameters, described in the table below. If the length of the string in the column doesn't fall within the range specified by (`minLength`, `maxLength`), both inclusive, the check will fail.
 At least one of `minLength` or `maxLength` must be specified. The data type of `column` must be String.
 
-| Arg | Type | Description |
-|-----|------|-------------|
-| `column` | String | Table column to be checked. The DataType of the column must be a String
-| `minLength` | Integer | Lower bound of the length of the string, inclusive.
-| `maxLength` | Integer | Upper bound of the length of the string, inclusive.
-| `threshold` | String | See above description of threshold.
+| Arg         | Type    | Description                                                             |
+|-------------|---------|-------------------------------------------------------------------------|
+| `column`    | String  | Table column to be checked. The DataType of the column must be a String |
+| `minLength` | Integer | Lower bound of the length of the string, inclusive.                     |
+| `maxLength` | Integer | Upper bound of the length of the string, inclusive.                     |
+| `threshold` | String  | See above description of threshold.                                     |
 
 #### `stringRegexCheck`
 
@@ -318,9 +318,9 @@ A value for `regex` must be specified. The data type of `column` must be String.
 
 The minimum number of rows a table must have to pass the validator.
 
-| Arg | Type | Description |
-|-----|------|-------------|
-| `minNumRows` | Long | The minimum number of rows a table must have to pass.
+| Arg          | Type | Description                                           |
+|--------------|------|-------------------------------------------------------|
+| `minNumRows` | Long | The minimum number of rows a table must have to pass. |
 
 See Example Config file below to see how the checks are configured.
 
@@ -329,9 +329,9 @@ See Example Config file below to see how the checks are configured.
 This check is used to make sure all rows in the table are unique, only the columns specified are used to determine uniqueness.
 This is a costly check and requires an additional pass through the table.
 
-| Arg | Type | Description |
-|-----|------|-------------|
-| `columns` | Array[String] | Each set of values in these columns must be unique.
+| Arg       | Type          | Description                                         |
+|-----------|---------------|-----------------------------------------------------|
+| `columns` | Array[String] | Each set of values in these columns must be unique. |
 
 #### `columnSumCheck`
 

--- a/README.md
+++ b/README.md
@@ -231,9 +231,9 @@ To validate an `.parquet` file, specify `parquetFile` and the path to the file, 
   checks:
 ```
 
-#### Custom reader format
+#### Core `spark.read` fluent API
 
-To validate data loadable by a custom dynamic format reader, use something like this:
+To validate data loadable by the Spark DataFrameReader Fluent API, use something like this:
 
 ```yaml
   # Some systems require a special format

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ To validate data loadable by the Spark DataFrameReader Fluent API, use something
   # If omitted, then DV will call DataFrameReader.load() without parameters.
   # The DataSource that Spark loads is expected to know how to handle this.
   # This only handles a single string value, not a list.
-  load: /path/to/something/camelid.llama
+  loadData: /path/to/something/camelid.llama
   keyColumns:
     - col1
     - col2

--- a/README.md
+++ b/README.md
@@ -231,9 +231,32 @@ To validate an `.parquet` file, specify `parquetFile` and the path to the file, 
   checks:
 ```
 
+#### Custom reader format
+
+To validate data loadable by a custom dynamic format reader, use something like this:
+
+```yaml
+  # Some systems require a special format
+  format: llama
+  # You can also pass any valid options
+  options:
+    key: value
+    user: 
+  # This is a string passed to DataFrameReader.load(String)
+  # If omitted, then DV will call DataFrameReader.load() without parameters.
+  # The DataSource that Spark loads is expected to know how to handle this.
+  # This only handles a single string value, not a list.
+  load: /path/to/something/camelid.llama
+  keyColumns:
+    - col1
+    - col2
+  condition: "col1 < 100"
+  checks:
+```
+
 ### Validators
 
-  The third section are the validators. To specify a validator, you
+The third section are the validators. To specify a validator, you
 first specify the type as one of the validators, then specify the
 arguments for that validator. Some of the validators support an error
 threshold. This options allows the user to specify the number of errors

--- a/src/main/scala/com/target/data_validator/ConfigParser.scala
+++ b/src/main/scala/com/target/data_validator/ConfigParser.scala
@@ -21,7 +21,7 @@ object ConfigParser extends LazyLogging {
       Decoder[ValidatorHiveTable].widen,
       Decoder[ValidatorOrcFile].widen,
       Decoder[ValidatorParquetFile].widen,
-      Decoder[ValidatorCustomFormat].widen
+      Decoder[ValidatorSpecifiedFormatLoader].widen
     ).reduceLeft(_ or _)
 
   def configFromJson(json: Json): Either[DecodingFailure, ValidatorConfig] = {

--- a/src/main/scala/com/target/data_validator/ConfigParser.scala
+++ b/src/main/scala/com/target/data_validator/ConfigParser.scala
@@ -20,7 +20,8 @@ object ConfigParser extends LazyLogging {
     List[Decoder[ValidatorTable]](
       Decoder[ValidatorHiveTable].widen,
       Decoder[ValidatorOrcFile].widen,
-      Decoder[ValidatorParquetFile].widen
+      Decoder[ValidatorParquetFile].widen,
+      Decoder[ValidatorCustomFormat].widen
     ).reduceLeft(_ or _)
 
   def configFromJson(json: Json): Either[DecodingFailure, ValidatorConfig] = {

--- a/src/main/scala/com/target/data_validator/JsonEncoders.scala
+++ b/src/main/scala/com/target/data_validator/JsonEncoders.scala
@@ -108,6 +108,15 @@ object JsonEncoders extends LazyLogging {
         ("checks", vdf.checks.asJson),
         ("events", vdf.getEvents.asJson)
       )
+      case vcf: ValidatorCustomFormat => Json.obj(
+        ("format", Json.fromString(vcf.format)),
+        ("options", vcf.options.asJson),
+        ("loadData", vcf.loadData.asJson),
+        ("failed", vcf.failed.asJson),
+        ("keyColumns", vcf.keyColumns.asJson),
+        ("checks", vcf.checks.asJson),
+        ("events", vcf.getEvents.asJson)
+      )
     }
   }
 

--- a/src/main/scala/com/target/data_validator/JsonEncoders.scala
+++ b/src/main/scala/com/target/data_validator/JsonEncoders.scala
@@ -108,7 +108,7 @@ object JsonEncoders extends LazyLogging {
         ("checks", vdf.checks.asJson),
         ("events", vdf.getEvents.asJson)
       )
-      case vcf: ValidatorCustomFormat => Json.obj(
+      case vcf: ValidatorSpecifiedFormatLoader => Json.obj(
         ("format", Json.fromString(vcf.format)),
         ("options", vcf.options.asJson),
         ("loadData", vcf.loadData.asJson),

--- a/src/main/scala/com/target/data_validator/ValidatorTable.scala
+++ b/src/main/scala/com/target/data_validator/ValidatorTable.scala
@@ -253,18 +253,19 @@ case class ValidatorHiveTable(
 }
 
 /**
- * Enables usage of the `spark.read.format(String).options(Map[String,String]).load()` API
+ * Enables usage of the normal `spark.read.format(String).options(Map[String,String]).load()` fluent API
  * for creating a [[DataFrame]] using a dynamic loader.
  *
  * For reading well-known formats such as Parquet or ORC,
  * use [[ValidatorParquetFile]] or [[ValidatorOrcFile]], respectively.
+ * Under the hood, these just call `spark.read.format("orc")` but let's let Spark handle that.
  *
  * @param format the format that the [[DataFrameReader]] should use
  * @param options options that the [[DataFrameReader]] should use
  * @param loadData If present, this will passed to [[DataFrameReader.load(String)]],
  *                 otherwise the DFR will use the parameterless version
  */
-case class ValidatorCustomFormat(
+case class ValidatorSpecifiedFormatLoader(
   format: String,
   keyColumns: Option[List[String]],
   condition: Option[String],
@@ -299,7 +300,7 @@ case class ValidatorCustomFormat(
 
     val newBases = substituteKeyColsCondsChecks(dict)
 
-    val ret = ValidatorCustomFormat(
+    val ret = ValidatorSpecifiedFormatLoader(
       newFormat,
       newBases.keyColumns.map(_.toList),
       newBases.condition,

--- a/src/main/scala/com/target/data_validator/ValidatorTable.scala
+++ b/src/main/scala/com/target/data_validator/ValidatorTable.scala
@@ -270,7 +270,7 @@ case class ValidatorSpecifiedFormatLoader(
   keyColumns: Option[List[String]],
   condition: Option[String],
   checks: List[ValidatorBase],
-  options: Map[String, String] = Map.empty,
+  options: Option[Map[String, String]] = None,
   loadData: Option[String] = None
 ) extends ValidatorTable(
   keyColumns,
@@ -285,7 +285,7 @@ case class ValidatorSpecifiedFormatLoader(
     }
 
     Try {
-      val optionedReader = session.read.format(format).options(options)
+      val optionedReader = session.read.format(format).options(options.getOrElse(Map.empty))
       // TODO: support the varargs version of load()
       loadData.fold(ifEmpty = optionedReader.load())(optionedReader.load)
     }
@@ -294,9 +294,9 @@ case class ValidatorSpecifiedFormatLoader(
   override def substituteVariables(dict: VarSubstitution): ValidatorTable = {
     val newFormat = getVarSub(format, "format", dict)
     val newLoadData = loadData.map(getVarSub(_, "loadData", dict))
-    val newOptions = options.map {
+    val newOptions = options.map { _.map {
       case (optKey, optVal) => optKey -> getVarSub(optVal, optKey, dict)
-    }
+    } }
 
     val newBases = substituteKeyColsCondsChecks(dict)
 

--- a/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
+++ b/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
@@ -183,8 +183,44 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
 
       }
 
+      describe("should work for the unique parts of ValidatorCustomFormat") {
+        val dict = mkDict(
+          ("format", "foobar"),
+          ("loadData", "barfoo"),
+          ("optionRep1", "who"),
+          ("optionRep2", "what")
+        )
+
+        it ("format") {
+          val vt = ValidatorCustomFormat("${format}", None, None, List.empty) // scalastyle:ignore
+          val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorCustomFormat]
+
+          assert(sut == vt.copy(format = "foobar"))
+          assert(sut.getEvents contains VarSubEvent("${format}", "foobar")) // scalastyle:ignore
+        }
+        it ("loadData") {
+          val vt = ValidatorCustomFormat("foobar", None, None, List.empty, loadData = Some("${loadData}")) // scalastyle:ignore
+          val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorCustomFormat]
+
+          assert(sut == vt.copy(loadData = Option("barfoo")))
+          assert(sut.getEvents contains VarSubEvent("${loadData}", "barfoo")) // scalastyle:ignore
+        }
+        it ("options") {
+          val vt = ValidatorCustomFormat("foobar", None, None, List.empty,
+            options = Map(
+              "something" -> "${optionRep1}",
+              "somethingElse" -> "${optionRep2}"
+            ))
+          val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorCustomFormat]
+
+          assert(sut == vt.copy(options = Map(
+            "something" -> "who",
+            "somethingElse" -> "what"
+          )))
+          assert(sut.getEvents contains VarSubEvent("${optionRep1}", "who")) // scalastyle:ignore
+          assert(sut.getEvents contains VarSubEvent("${optionRep2}", "what")) // scalastyle:ignore
+        }
+      }
     }
-
   }
-
 }

--- a/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
+++ b/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
@@ -199,10 +199,10 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
           assert(sut.getEvents contains VarSubEvent("${format}", "foobar")) // scalastyle:ignore
         }
         it ("loadData") {
-          val vt = ValidatorSpecifiedFormatLoader("foobar", None, None, List.empty, loadData = Some("${loadData}")) // scalastyle:ignore
+          val vt = ValidatorSpecifiedFormatLoader("foobar", None, None, List.empty, loadData = Some(List("${loadData}"))) // scalastyle:ignore
           val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorSpecifiedFormatLoader]
 
-          assert(sut == vt.copy(loadData = Option("barfoo")))
+          assert(sut == vt.copy(loadData = Option(List("barfoo"))))
           assert(sut.getEvents contains VarSubEvent("${loadData}", "barfoo")) // scalastyle:ignore
         }
         it ("options") {

--- a/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
+++ b/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
@@ -192,26 +192,26 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
         )
 
         it ("format") {
-          val vt = ValidatorCustomFormat("${format}", None, None, List.empty) // scalastyle:ignore
-          val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorCustomFormat]
+          val vt = ValidatorSpecifiedFormatLoader("${format}", None, None, List.empty) // scalastyle:ignore
+          val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorSpecifiedFormatLoader]
 
           assert(sut == vt.copy(format = "foobar"))
           assert(sut.getEvents contains VarSubEvent("${format}", "foobar")) // scalastyle:ignore
         }
         it ("loadData") {
-          val vt = ValidatorCustomFormat("foobar", None, None, List.empty, loadData = Some("${loadData}")) // scalastyle:ignore
-          val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorCustomFormat]
+          val vt = ValidatorSpecifiedFormatLoader("foobar", None, None, List.empty, loadData = Some("${loadData}")) // scalastyle:ignore
+          val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorSpecifiedFormatLoader]
 
           assert(sut == vt.copy(loadData = Option("barfoo")))
           assert(sut.getEvents contains VarSubEvent("${loadData}", "barfoo")) // scalastyle:ignore
         }
         it ("options") {
-          val vt = ValidatorCustomFormat("foobar", None, None, List.empty,
+          val vt = ValidatorSpecifiedFormatLoader("foobar", None, None, List.empty,
             options = Map(
               "something" -> "${optionRep1}",
               "somethingElse" -> "${optionRep2}"
             ))
-          val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorCustomFormat]
+          val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorSpecifiedFormatLoader]
 
           assert(sut == vt.copy(options = Map(
             "something" -> "who",

--- a/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
+++ b/src/test/scala/com/target/data_validator/ValidatorTableSpec.scala
@@ -207,16 +207,16 @@ class ValidatorTableSpec extends FunSpec with Matchers with TestingSparkSession 
         }
         it ("options") {
           val vt = ValidatorSpecifiedFormatLoader("foobar", None, None, List.empty,
-            options = Map(
+            options = Some(Map(
               "something" -> "${optionRep1}",
               "somethingElse" -> "${optionRep2}"
-            ))
+            )))
           val sut = vt.substituteVariables(dict).asInstanceOf[ValidatorSpecifiedFormatLoader]
 
-          assert(sut == vt.copy(options = Map(
+          assert(sut == vt.copy(options = Some(Map(
             "something" -> "who",
             "somethingElse" -> "what"
-          )))
+          ))))
           assert(sut.getEvents contains VarSubEvent("${optionRep1}", "who")) // scalastyle:ignore
           assert(sut.getEvents contains VarSubEvent("${optionRep2}", "what")) // scalastyle:ignore
         }


### PR DESCRIPTION
This enables a user to run Data Validator checks on data sourced fromdynamically loaded DataSource plugins. These plugins often require options and can accept a file path or other loading data.

This enables Data Validator to support formats for which it hasn't yet implemented direct support.

Fixes #78