### PR TITLE
Drops Hive dependency

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -40,8 +40,7 @@ pullRequests.frequency = "7 days"
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
 updates.pin  = [
-  { groupId = "org.apache.spark", artifactId="spark-sql", version = "2.3." },
-  { groupId = "org.apache.spark", artifactId="spark-hive", version = "2.3." },
+  { groupId = "org.apache.spark", artifactId="spark-sql", version = "2.3." }
  ]
 
 # The dependencies which match the given pattern are NOT updated.

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,6 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
-  "org.apache.spark" %% "spark-hive" % sparkVersion % Provided,
 
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "junit" % "junit" % "4.12" % Test,


### PR DESCRIPTION
It may have needed to be there, but it doesn't need to be there anymore! @c-horn caught it on a review for #85.