### PR TITLE
Reintroduces scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,14 @@
+version = 3.5.8
+runner.dialect = scala211
+project.git = true
+align.preset = none
+# Disabled in default since this operation is potentially
+# dangerous if you define your own stripMargin with different
+# semantics from the stdlib stripMargin.
+assumeStandardLibraryStripMargin = true
+onTestFailure = "To fix this, run 'sbt scalafmt' from the project root directory"
+maxColumn = 118
+rewrite.rules = [RedundantParens, PreferCurlyFors, SortModifiers]
+docstrings.style = SpaceAsterisk
+indent.main = 2
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SCALAFMT ?= bin/scalafmt
+SBT ?= bin/sbt
 
 ##@ Utilities
 
@@ -15,26 +15,19 @@ deps-sys: Brewfile ## Installs system-wide dependencies
 
 .PHONY: test
 test: ## Runs tests
-	bin/sbt test
+	$(SBT) test
 
 .PHONY: check
 check: ## Runs linters and other checks
-	bin/sbt scalastyle
+	$(SBT) scalastyle
 
 .PHONY: build
 build:
-	bin/sbt assembly
+	$(SBT) assembly
 
 .PHONY: format-scala
-format-scala: $(SCALAFMT) ## Formats all Scala code
-	$(SCALAFMT)
-
-SCALAFMT_VERSION ?= "$(shell grep "sbt-scalafmt" "build.sbt" | cut -d "%" -f 3 | sed -e 's/[^\.0-9A-Za-z-]//g' )"
-$(SCALAFMT):
-	coursier bootstrap org.scalameta:scalafmt-cli_2.12:$(SCALAFMT_VERSION) \
-		-r sonatype:releases \
-		-o $@ \
-		--main org.scalafmt.cli.Cli
+format-scala: ## Formats all Scala code
+	$(SBT) scalafmt
 
 ##@ Maintenance Tasks
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,10 +20,9 @@ githubRepository := "data-validator"
 // this unfortunately must be set strangely because GitHub requires a token for pulling packages
 // and sbt-github-packages does not allow the user to configure the resolver not to be used.
 // https://github.com/djspiewak/sbt-github-packages/issues/28
-githubTokenSource := (
-  TokenSource.Environment("GITHUB_TOKEN") ||
-    TokenSource.GitConfig("github.token") ||
-    TokenSource.Environment("SHELL") ) // it's safe to assume this exists and is not unique
+githubTokenSource := (TokenSource.Environment("GITHUB_TOKEN") ||
+  TokenSource.GitConfig("github.token") ||
+  TokenSource.Environment("SHELL")) // it's safe to assume this exists and is not unique
 
 publishTo := githubPublishTo.value
 
@@ -42,19 +41,20 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
   "org.apache.spark" %% "spark-hive" % sparkVersion % Provided,
-
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "junit" % "junit" % "4.12" % Test,
-  "com.novocode" % "junit-interface" % "0.11" % Test exclude("junit", "junit-dep")
+  "com.novocode" % "junit-interface" % "0.11" % Test exclude ("junit", "junit-dep")
 )
 
 Test / fork := true
 javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled")
 Test / parallelExecution := false
 // required for unit tests, but not set in some environments
-Test / envVars ++= Map("JAVA_HOME" ->
-  Option(System.getenv("JAVA_HOME"))
-    .getOrElse(System.getProperty("java.home")))
+Test / envVars ++= Map(
+  "JAVA_HOME" ->
+    Option(System.getenv("JAVA_HOME"))
+      .getOrElse(System.getProperty("java.home"))
+)
 
 assembly / mainClass := Some("com.target.data_validator.Main")
 
@@ -66,13 +66,15 @@ scalastyleFailOnError := true
 compileScalastyle := (Compile / scalastyle).toTask("").value
 (Compile / compile) := ((Compile / compile) dependsOn compileScalastyle).value
 
-(Compile / run) := Defaults.runTask(
-  (Compile / fullClasspath),
-  (Compile / run / mainClass),
-  (Compile / run / runner)
-).evaluated
+(Compile / run) := Defaults
+  .runTask(
+    Compile / fullClasspath,
+    Compile / run / mainClass,
+    Compile / run / runner
+  )
+  .evaluated
 
-(Compile / runMain) := Defaults.runMainTask((Compile / fullClasspath), (Compile / run / runner)).evaluated
+(Compile / runMain) := Defaults.runMainTask(Compile / fullClasspath, Compile / run / runner).evaluated
 TaskKey[Unit]("generateTestData") := {
   libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion
   (Compile / runMain).toTask(" com.target.data_validator.GenTestData").value

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,4 +3,3 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,5 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 

--- a/src/main/scala/com/target/data_validator/CliOptionParser.scala
+++ b/src/main/scala/com/target/data_validator/CliOptionParser.scala
@@ -3,13 +3,13 @@ package com.target.data_validator
 import scopt.OptionParser
 
 case class CliOptions(
-  configFilename: String = "",
-  verbose: Boolean = false,
-  jsonReport: Option[String] = None,
-  htmlReport: Option[String] = None,
-  exitErrorOnFail: Boolean = true,
-  vars: Map[String, String] = Map(),
-  emailOnPass: Boolean = false
+    configFilename: String = "",
+    verbose: Boolean = false,
+    jsonReport: Option[String] = None,
+    htmlReport: Option[String] = None,
+    exitErrorOnFail: Boolean = true,
+    vars: Map[String, String] = Map(),
+    emailOnPass: Boolean = false
 )
 
 object CliOptionParser {
@@ -19,30 +19,36 @@ object CliOptionParser {
 
     version("version")
 
-    opt[Unit]("verbose").action((_, c) =>
-      c.copy(verbose = true)).text("Print additional debug output.")
+    opt[Unit]("verbose").action((_, c) => c.copy(verbose = true)).text("Print additional debug output.")
 
-    opt[String]("config").action((fn, c) =>
-      c.copy(configFilename = fn))
+    opt[String]("config")
+      .action((fn, c) => c.copy(configFilename = fn))
       .text(
         "required validator config .yaml filename, " +
           "prefix w/ 'classpath:' to load configuration from JVM classpath/resources, " +
-          "ex. '--config classpath:/config.yaml'")
+          "ex. '--config classpath:/config.yaml'"
+      )
 
-    opt[String]("jsonReport").action((fn, c) =>
-      c.copy(jsonReport = Some(fn))).text("optional JSON report filename")
+    opt[String]("jsonReport").action((fn, c) => c.copy(jsonReport = Some(fn))).text("optional JSON report filename")
 
-    opt[String]("htmlReport").action((fn, c) =>
-      c.copy(htmlReport = Some(fn))).text("optional HTML report filename")
+    opt[String]("htmlReport").action((fn, c) => c.copy(htmlReport = Some(fn))).text("optional HTML report filename")
 
-    opt[Map[String, String]]("vars").valueName("k1=v1,k2=v2...").action((x, c) =>
-      c.copy(vars = x)).text("other arguments")
+    opt[Map[String, String]]("vars")
+      .valueName("k1=v1,k2=v2...")
+      .action((x, c) => c.copy(vars = x))
+      .text("other arguments")
 
-    opt[Boolean]("exitErrorOnFail").valueName("true|false").action((x, c) => c.copy(exitErrorOnFail = x))
-      .text("optional when true, if validator fails, call System.exit(-1) " +
-        "Defaults to True, but will change to False in future version.")
+    opt[Boolean]("exitErrorOnFail")
+      .valueName("true|false")
+      .action((x, c) => c.copy(exitErrorOnFail = x))
+      .text(
+        "optional when true, if validator fails, call System.exit(-1) " +
+          "Defaults to True, but will change to False in future version."
+      )
 
-    opt[Boolean]("emailOnPass").valueName("true|false").action((x, c) => c.copy(emailOnPass = x))
+    opt[Boolean]("emailOnPass")
+      .valueName("true|false")
+      .action((x, c) => c.copy(emailOnPass = x))
       .text("optional when true, sends email on validation success. Default: false")
 
     help("help").text("Show this help message and exit.")

--- a/src/main/scala/com/target/data_validator/ConfigVar.scala
+++ b/src/main/scala/com/target/data_validator/ConfigVar.scala
@@ -56,7 +56,9 @@ case class NameShell(name: String, shell: String) extends ConfigVar {
         case Failure(exception) =>
           validatorError(s"NameShell($name, $newShell) Failed with exception $exception"); true
         case Success(exitCode) if exitCode != 0 =>
-          validatorError(s"NameShell($name, $newShell) Ran but returned exitCode: $exitCode stderr: ${err.toString()}")
+          validatorError(
+            s"NameShell($name, $newShell) Ran but returned exitCode: $exitCode stderr: ${err.toString()}"
+          )
           true
         case Success(0) if out.isEmpty =>
           validatorError(s"NameShell($name, $newShell) Ran but returned No output")

--- a/src/main/scala/com/target/data_validator/Emailer.scala
+++ b/src/main/scala/com/target/data_validator/Emailer.scala
@@ -9,13 +9,14 @@ import javax.mail.internet._
 import scala.util.Try
 
 case class EmailConfig(
-  smtpHost: String,
-  subject: String,
-  from: String,
-  to: List[String],
-  cc: Option[List[String]] = None,
-  bcc: Option[List[String]] = None
-) extends EventLog with Substitutable {
+    smtpHost: String,
+    subject: String,
+    from: String,
+    to: List[String],
+    cc: Option[List[String]] = None,
+    bcc: Option[List[String]] = None
+) extends EventLog
+    with Substitutable {
   def substituteVariables(dict: VarSubstitution): EmailConfig = {
     EmailConfig(
       getVarSub(smtpHost, "smtpHost", dict),
@@ -69,12 +70,12 @@ object Emailer extends LazyLogging {
   }
 
   def createEmptyMessage(
-    smtpHost: String,
-    subject: String,
-    from: String,
-    to: Seq[String],
-    cc: Seq[String],
-    bcc: Seq[String]
+      smtpHost: String,
+      subject: String,
+      from: String,
+      to: Seq[String],
+      cc: Seq[String],
+      bcc: Seq[String]
   ): Option[Message] = {
 
     logger.debug(s"Creating Message frm: $from to: ${to.mkString(", ")} sub: $subject")
@@ -114,8 +115,7 @@ object Emailer extends LazyLogging {
       Transport.send(message)
       logger.info(s"Email #$id sent successfully to all recipients.")
       false
-    }
-    catch {
+    } catch {
       case sfe: SendFailedException =>
         handleSendFailedException(id, sfe)
         true
@@ -142,13 +142,13 @@ object Emailer extends LazyLogging {
   }
 
   def sendTextMessage(
-    smtpHost: String,
-    body: String,
-    subject: String,
-    from: String,
-    to: Seq[String],
-    cc: Seq[String] = Nil,
-    bcc: Seq[String] = Nil
+      smtpHost: String,
+      body: String,
+      subject: String,
+      from: String,
+      to: Seq[String],
+      cc: Seq[String] = Nil,
+      bcc: Seq[String] = Nil
   ): Boolean =
     createEmptyMessage(smtpHost, subject, from, to, cc, bcc) match {
       case None =>
@@ -159,7 +159,7 @@ object Emailer extends LazyLogging {
     }
 
   def sendTextMessage(emailConfig: EmailConfig, body: String): Boolean = {
-    createEmptyMessage(emailConfig) match  {
+    createEmptyMessage(emailConfig) match {
       case None =>
         logger.error("createMessage failed!")
         true
@@ -169,13 +169,13 @@ object Emailer extends LazyLogging {
   }
 
   def sendHtmlMessage(
-    smtpHost: String,
-    body: String,
-    subject: String,
-    from: String,
-    to: Seq[String],
-    cc: Seq[String] = Nil,
-    bcc: Seq[String] = Nil
+      smtpHost: String,
+      body: String,
+      subject: String,
+      from: String,
+      to: Seq[String],
+      cc: Seq[String] = Nil,
+      bcc: Seq[String] = Nil
   ): Boolean =
     createEmptyMessage(smtpHost, subject, from, to, cc, bcc) match {
       case None =>

--- a/src/main/scala/com/target/data_validator/EnvironmentVariables.scala
+++ b/src/main/scala/com/target/data_validator/EnvironmentVariables.scala
@@ -13,15 +13,13 @@ object EnvironmentVariables {
       whenError = { case throwable: Throwable => Inaccessible(throwable) },
       whenUnset = { Unset },
       whenPresent = { Present }
-    )
-      .recover { case throwable: Throwable => Error(throwable) }
-      .get
+    ).recover { case throwable: Throwable => Error(throwable) }.get
   }
 
   def getWithHandlers[T](key: String)(
-    whenError: PartialFunction[Throwable, T],
-    whenUnset: => T,
-    whenPresent: String => T
+      whenError: PartialFunction[Throwable, T],
+      whenUnset: => T,
+      whenPresent: String => T
   ): Try[T] = {
     tryGet(key)
       .map(_.map(whenPresent).getOrElse(whenUnset))

--- a/src/main/scala/com/target/data_validator/ExpressionUtils.scala
+++ b/src/main/scala/com/target/data_validator/ExpressionUtils.scala
@@ -3,11 +3,12 @@ package com.target.data_validator
 import org.apache.spark.sql.catalyst.expressions.{Expression, Or}
 
 object ExpressionUtils {
-  /**
-    * Takes a List[Expression] and joins them together into on big Or() expression.
-    * @param exprs - Non Empty List of Expressions.
-    * @return Or of all Expressions.
-    * throws IllegalArgumentException if exprs is empty.
+
+  /** Takes a List[Expression] and joins them together into on big Or() expression.
+    * @param exprs
+    *   \- Non Empty List of Expressions.
+    * @return
+    *   Or of all Expressions. throws IllegalArgumentException if exprs is empty.
     */
   @throws[IllegalArgumentException]
   def orFromList(exprs: List[Expression]): Expression = exprs match {

--- a/src/main/scala/com/target/data_validator/GenTestData.scala
+++ b/src/main/scala/com/target/data_validator/GenTestData.scala
@@ -10,7 +10,8 @@ object GenTestData {
       StructField("id", IntegerType),
       StructField("label", StringType),
       StructField("div7", StringType, nullable = true)
-    ))
+    )
+  )
 
   val label: Vector[String] = Vector("zero", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine")
 
@@ -26,7 +27,8 @@ object GenTestData {
   def genData(spark: SparkSession): DataFrame = {
     val rg = spark.sparkContext.parallelize(Range(0, 100)) // scalastyle:off magic.number
     spark.createDataFrame(
-      rg.map(x => Row(x, mkLabel(x).reverse.mkString(" "), if (x % 7 == 0) null else "NotNull")), // scalastyle:off null
+      rg.map(x => Row(x, mkLabel(x).reverse.mkString(" "), if (x % 7 == 0) null else "NotNull") // scalastyle:off null
+      ),
       schema
     )
   }

--- a/src/main/scala/com/target/data_validator/HTMLBits.scala
+++ b/src/main/scala/com/target/data_validator/HTMLBits.scala
@@ -2,12 +2,12 @@ package com.target.data_validator
 
 import scalatags.Text.all._
 
-/**
-  * Place for various HTMLBits that are used in generating HTML report.
+/** Place for various HTMLBits that are used in generating HTML report.
   */
 object HTMLBits {
-  def pass: Tag = span(backgroundColor:= "mediumseagreen")("PASS")
-  def fail: Tag = span(backgroundColor:= "tomato")("FAIL")
+  def pass: Tag = span(backgroundColor := "mediumseagreen")("PASS")
+  def fail: Tag = span(backgroundColor := "tomato")("FAIL")
 
-  def status(failed: Boolean): Tag = if (failed) { fail } else { pass }
+  def status(failed: Boolean): Tag = if (failed) { fail }
+  else { pass }
 }

--- a/src/main/scala/com/target/data_validator/IO.scala
+++ b/src/main/scala/com/target/data_validator/IO.scala
@@ -23,18 +23,21 @@ object IO extends LazyLogging {
   val FILE_SCHEMA_PREFIX = "file://"
   val HDFS_SCHEMA_PREFIX = "hdfs://"
 
-  /**
-    * Helper for calling right function for local or hdfs files.
-    * @param localFunc - If filename is local call this function.
-    * @param hdfsFunc - If filename is HDFS call this function
-    * @param default - default to return when exception is thrown.
-    * @return depends on semantics of localFunc/hdfsFunc.
+  /** Helper for calling right function for local or hdfs files.
+    * @param localFunc
+    *   \- If filename is local call this function.
+    * @param hdfsFunc
+    *   \- If filename is HDFS call this function
+    * @param default
+    *   \- default to return when exception is thrown.
+    * @return
+    *   depends on semantics of localFunc/hdfsFunc.
     */
   private def localOrHdfs(
-    filename: String,
-    localFunc: String => Boolean,
-    hdfsFunc: String => Boolean,
-    default: Boolean = false
+      filename: String,
+      localFunc: String => Boolean,
+      hdfsFunc: String => Boolean,
+      default: Boolean = false
   )(implicit spark: SparkSession): Boolean = {
     if (filename.startsWith(HDFS_SCHEMA_PREFIX)) {
       hdfsFunc(filename)
@@ -43,8 +46,7 @@ object IO extends LazyLogging {
     } else {
       try {
         localFunc(filename)
-      }
-      catch {
+      } catch {
         case re: RemoteException => logger.warn(s"Caught Exception, $re"); default
       }
     }
@@ -70,11 +72,12 @@ object IO extends LazyLogging {
   }
 
   private def parentIsWritable(fs: FileSystem, path: Path): Boolean = Option(path.getParent) match {
-    case Some(parent) => if (fs.exists(parent)) {
-      pathCanWrite(fs, parent)
-    } else {
-      parentIsWritable(fs, parent)
-    }
+    case Some(parent) =>
+      if (fs.exists(parent)) {
+        pathCanWrite(fs, parent)
+      } else {
+        parentIsWritable(fs, parent)
+      }
     case None => logger.warn("getParent returned NULL"); false
   }
 
@@ -119,12 +122,14 @@ object IO extends LazyLogging {
     f.canExecute
   }
 
-  /**
-    * Checks a file to see if it can be appended to or created if it doesn't exist.
+  /** Checks a file to see if it can be appended to or created if it doesn't exist.
     *
-    * @param append - true if we can append to file.
-    * @param spark - SparkSession.
-    * @return  true - should be able to create or append.
+    * @param append
+    *   \- true if we can append to file.
+    * @param spark
+    *   \- SparkSession.
+    * @return
+    *   true - should be able to create or append.
     */
   def canAppendOrCreate(filename: String, append: Boolean)(implicit spark: SparkSession): Boolean =
     localOrHdfs(
@@ -133,10 +138,10 @@ object IO extends LazyLogging {
       (f: String) => canAppendOrCreateHDFS(f, append)
     )
 
-  /**
-    *  Checks a filename to see if its Executable.
+  /** Checks a filename to see if its Executable.
     *
-    * @return true if executable.
+    * @return
+    *   true if executable.
     */
   def canExecute(filename: String)(implicit spark: SparkSession): Boolean = {
     localOrHdfs(filename, canExecuteLocal, (_: String) => false)
@@ -146,9 +151,9 @@ object IO extends LazyLogging {
     try {
       val file = new File(filename)
       file.exists()
-    }
-    catch {
-      case ioe: IOException => logger.warn(s"Exception caught '$filename' ioe: $ioe")
+    } catch {
+      case ioe: IOException =>
+        logger.warn(s"Exception caught '$filename' ioe: $ioe")
         false
     }
   }
@@ -159,21 +164,27 @@ object IO extends LazyLogging {
   }
 
   /** Checks for existence of file
-    * @param filename - file to check for existence.
-    * @param spark - SparkSession
-    * @return true if file exists
+    * @param filename
+    *   \- file to check for existence.
+    * @param spark
+    *   \- SparkSession
+    * @return
+    *   true if file exists
     */
   def exists(filename: String)(implicit spark: SparkSession): Boolean = {
     localOrHdfs(filename, existsLocal, existsHDFS)
   }
 
-  /**
-    * Writes a string to local or HDFS
+  /** Writes a string to local or HDFS
     *
-    * @param filename - Where to write str.
-    * @param str      - String to write to filename
-    * @param append   - True = append
-    * @return true on error
+    * @param filename
+    *   \- Where to write str.
+    * @param str
+    *   \- String to write to filename
+    * @param append
+    *   \- True = append
+    * @return
+    *   true on error
     */
   def writeString(filename: String, str: String, append: Boolean = false)(implicit spark: SparkSession): Boolean = {
     localOrHdfs(
@@ -183,13 +194,16 @@ object IO extends LazyLogging {
     )
   }
 
-  /**
-    * Writes a string to a local filesystem.
+  /** Writes a string to a local filesystem.
     *
-    * @param filename - Where to write str, if string doesn't end in new line, one will be appended.
-    * @param str      - String to write to filename
-    * @param append   - True = append
-    * @return true on error
+    * @param filename
+    *   \- Where to write str, if string doesn't end in new line, one will be appended.
+    * @param str
+    *   \- String to write to filename
+    * @param append
+    *   \- True = append
+    * @return
+    *   true on error
     */
   def writeStringLocal(filename: String, str: String, append: Boolean): Boolean = {
     try {
@@ -206,40 +220,49 @@ object IO extends LazyLogging {
     }
   }
 
-  /**
-    * Writes HTML to filename
+  /** Writes HTML to filename
     *
-    * @param filename - where to write HTML
-    * @param html     - HTML to write to filename
-    * @return true on error
+    * @param filename
+    *   \- where to write HTML
+    * @param html
+    *   \- HTML to write to filename
+    * @return
+    *   true on error
     */
   def writeHTML(filename: String, html: Tag)(implicit spark: SparkSession): Boolean =
     writeString(filename, html.render)
 
-  /**
-    * Writes JSON to filename
+  /** Writes JSON to filename
     *
-    * @param filename - Where to write JSON
-    * @param json     - A JSON struct that will be written with noSpaces
-    * @param append   - True = append
-    * @return true on error
+    * @param filename
+    *   \- Where to write JSON
+    * @param json
+    *   \- A JSON struct that will be written with noSpaces
+    * @param append
+    *   \- True = append
+    * @return
+    *   true on error
     */
   def writeJSON(filename: String, json: Json, append: Boolean = false)(implicit spark: SparkSession): Boolean =
     writeString(filename, json.noSpaces, append)
 
-  /**
-    * Writes a String to HDFS path. If file exists, it will be overwritten. Returns true on error
+  /** Writes a String to HDFS path. If file exists, it will be overwritten. Returns true on error
     *
-    * @param filename - HDFS Path
-    * @param str      - String to write to filename
-    * @param append   - True = append
-    * @param spark    - Spark session to get hdfs conf
-    * @return true on failure
+    * @param filename
+    *   \- HDFS Path
+    * @param str
+    *   \- String to write to filename
+    * @param append
+    *   \- True = append
+    * @param spark
+    *   \- Spark session to get hdfs conf
+    * @return
+    *   true on failure
     */
   def writeStringToHdfs(
-    filename: String,
-    str: String,
-    append: Boolean = false
+      filename: String,
+      str: String,
+      append: Boolean = false
   )(implicit spark: SparkSession): Boolean = {
     try {
       val fs = FileSystem.get(URI.create(filename), spark.sparkContext.hadoopConfiguration)
@@ -263,11 +286,12 @@ object IO extends LazyLogging {
     }
   }
 
-  /**
-    *
-    * @param program - program to pipe str to.
-    * @param str - str to send to program.
-    * @return (fail: Boolean, stdout: String, stderr: String)
+  /** @param program
+    *   \- program to pipe str to.
+    * @param str
+    *   \- str to send to program.
+    * @return
+    *   (fail: Boolean, stdout: String, stderr: String)
     */
   def writeStringToPipe(program: String, str: String): (Boolean, Seq[String], Seq[String]) = {
 
@@ -277,7 +301,7 @@ object IO extends LazyLogging {
       val pLog = ProcessLogger(out.append(_), err.append(_))
 
       logger.info(s"Sending ${str.length} of input to `$program`")
-      val exitValue = Seq("sh", "-c", program) #< bis ! (pLog)
+      val exitValue = Seq("sh", "-c", program) #< bis ! pLog
       logger.debug(s"exitValue: $exitValue")
       if (logger.underlying.isDebugEnabled()) {
         out.foreach(o => logger.debug(s"stdout: $o"))

--- a/src/main/scala/com/target/data_validator/JsonEncoders.scala
+++ b/src/main/scala/com/target/data_validator/JsonEncoders.scala
@@ -15,61 +15,71 @@ object JsonEncoders extends LazyLogging {
     case d: Double => d.asJson
     case s: String => Json.fromString(s)
     case b: Boolean => b.asJson
-    case a: Any => logger.warn(s"Unknown type `${a.getClass.getCanonicalName}` defaulting to string.")
+    case a: Any =>
+      logger.warn(s"Unknown type `${a.getClass.getCanonicalName}` defaulting to string.")
       Json.fromString(a.toString)
   }
 
   // scalastyle:off cyclomatic.complexity
   implicit val eventEncoder: Encoder[ValidatorEvent] = new Encoder[ValidatorEvent] {
     override def apply(a: ValidatorEvent): Json = a match {
-      case vc: ValidatorCounter => Json.obj(
-        ("type", Json.fromString("counter")),
-        ("name", Json.fromString(vc.name)),
-        ("value", Json.fromLong(vc.value))
-      )
-      case vg: ValidatorGood => Json.obj(
-        ("type", Json.fromString("good")),
-        ("msg", Json.fromString(vg.msg))
-      )
-      case ve: ValidatorError => Json.obj(
-        ("type", Json.fromString("error")),
-        ("failed", Json.fromBoolean(ve.failed)),
-        ("msg", Json.fromString(ve.msg))
-      )
-      case vt: ValidatorTimer => Json.obj(
-        ("type", Json.fromString("timer")),
-        ("label", Json.fromString(vt.label)),
-        ("ns", Json.fromLong(vt.duration))
-      )
-      case vce: ValidatorCheckEvent => Json.obj(
-        ("type", Json.fromString("checkEvent")),
-        ("failed", Json.fromBoolean(vce.failed)),
-        ("label", Json.fromString(vce.label)),
-        ("count", Json.fromLong(vce.count)),
-        ("errorCount", Json.fromLong(vce.errorCount))
-      )
-      case cbvce: ColumnBasedValidatorCheckEvent => Json.obj(
-        ("type", Json.fromString("columnBasedCheckEvent")),
-        ("failed", Json.fromBoolean(cbvce.failed)),
-        ("message", Json.fromString(cbvce.msg)),
-        ("data", Json.fromFields(cbvce.data.map(x => (x._1, Json.fromString(x._2)))))
-      )
-      case qce: ValidatorQuickCheckError => Json.obj(
-        ("type", Json.fromString("quickCheckError")),
-        ("failed", Json.fromBoolean(qce.failed)),
-        ("message", Json.fromString(qce.message)),
-        ("key", Json.fromFields(qce.key.map(x => (x._1, any2json(x._2)))))
-      )
-      case vs: VarSubEvent => Json.obj(
-        ("type", Json.fromString("variableSubstitution")),
-        ("src", Json.fromString(vs.src)),
-        ("dest", Json.fromString(vs.dest))
-      )
-      case vs: VarSubJsonEvent => Json.obj(
-        ("type", Json.fromString("variableSubstitution")),
-        ("src", Json.fromString(vs.src)),
-        ("dest", vs.dest)
-      )
+      case vc: ValidatorCounter =>
+        Json.obj(
+          ("type", Json.fromString("counter")),
+          ("name", Json.fromString(vc.name)),
+          ("value", Json.fromLong(vc.value))
+        )
+      case vg: ValidatorGood =>
+        Json.obj(
+          ("type", Json.fromString("good")),
+          ("msg", Json.fromString(vg.msg))
+        )
+      case ve: ValidatorError =>
+        Json.obj(
+          ("type", Json.fromString("error")),
+          ("failed", Json.fromBoolean(ve.failed)),
+          ("msg", Json.fromString(ve.msg))
+        )
+      case vt: ValidatorTimer =>
+        Json.obj(
+          ("type", Json.fromString("timer")),
+          ("label", Json.fromString(vt.label)),
+          ("ns", Json.fromLong(vt.duration))
+        )
+      case vce: ValidatorCheckEvent =>
+        Json.obj(
+          ("type", Json.fromString("checkEvent")),
+          ("failed", Json.fromBoolean(vce.failed)),
+          ("label", Json.fromString(vce.label)),
+          ("count", Json.fromLong(vce.count)),
+          ("errorCount", Json.fromLong(vce.errorCount))
+        )
+      case cbvce: ColumnBasedValidatorCheckEvent =>
+        Json.obj(
+          ("type", Json.fromString("columnBasedCheckEvent")),
+          ("failed", Json.fromBoolean(cbvce.failed)),
+          ("message", Json.fromString(cbvce.msg)),
+          ("data", Json.fromFields(cbvce.data.map(x => (x._1, Json.fromString(x._2)))))
+        )
+      case qce: ValidatorQuickCheckError =>
+        Json.obj(
+          ("type", Json.fromString("quickCheckError")),
+          ("failed", Json.fromBoolean(qce.failed)),
+          ("message", Json.fromString(qce.message)),
+          ("key", Json.fromFields(qce.key.map(x => (x._1, any2json(x._2)))))
+        )
+      case vs: VarSubEvent =>
+        Json.obj(
+          ("type", Json.fromString("variableSubstitution")),
+          ("src", Json.fromString(vs.src)),
+          ("dest", Json.fromString(vs.dest))
+        )
+      case vs: VarSubJsonEvent =>
+        Json.obj(
+          ("type", Json.fromString("variableSubstitution")),
+          ("src", Json.fromString(vs.src)),
+          ("dest", vs.dest)
+        )
       case vj: JsonEvent => vj.json
     }
   }
@@ -80,64 +90,75 @@ object JsonEncoders extends LazyLogging {
   }
 
   implicit val tableEncoder: Encoder[ValidatorTable] = new Encoder[ValidatorTable] {
-    override final def apply(a: ValidatorTable): Json = a match {
-      case vh: ValidatorHiveTable => Json.obj(
-        ("db", Json.fromString(vh.db)),
-        ("table", Json.fromString(vh.table)),
-        ("failed", vh.failed.asJson),
-        ("keyColumns", vh.keyColumns.asJson),
-        ("checks", vh.checks.asJson),
-        ("events", vh.getEvents.asJson)
-      )
-      case vo: ValidatorOrcFile => Json.obj(
-        ("orcFile", Json.fromString(vo.orcFile)),
-        ("failed", vo.failed.asJson),
-        ("keyColumns", vo.keyColumns.asJson),
-        ("checks", vo.checks.asJson),
-        ("events", vo.getEvents.asJson))
-      case vp: ValidatorParquetFile => Json.obj(
-        ("parquetFile", Json.fromString(vp.parquetFile)),
-        ("failed", vp.failed.asJson),
-        ("keyColumns", vp.keyColumns.asJson),
-        ("checks", vp.checks.asJson),
-        ("events", vp.getEvents.asJson))
-      case vdf: ValidatorDataFrame => Json.obj(
-        ("dfLabel", vdf.label.asJson),
-        ("failed", vdf.failed.asJson),
-        ("keyColumns", vdf.keyColumns.asJson),
-        ("checks", vdf.checks.asJson),
-        ("events", vdf.getEvents.asJson)
-      )
-      case vcf: ValidatorSpecifiedFormatLoader => Json.obj(
-        ("format", Json.fromString(vcf.format)),
-        ("options", vcf.options.asJson),
-        ("loadData", vcf.loadData.asJson),
-        ("failed", vcf.failed.asJson),
-        ("keyColumns", vcf.keyColumns.asJson),
-        ("checks", vcf.checks.asJson),
-        ("events", vcf.getEvents.asJson)
-      )
+    final override def apply(a: ValidatorTable): Json = a match {
+      case vh: ValidatorHiveTable =>
+        Json.obj(
+          ("db", Json.fromString(vh.db)),
+          ("table", Json.fromString(vh.table)),
+          ("failed", vh.failed.asJson),
+          ("keyColumns", vh.keyColumns.asJson),
+          ("checks", vh.checks.asJson),
+          ("events", vh.getEvents.asJson)
+        )
+      case vo: ValidatorOrcFile =>
+        Json.obj(
+          ("orcFile", Json.fromString(vo.orcFile)),
+          ("failed", vo.failed.asJson),
+          ("keyColumns", vo.keyColumns.asJson),
+          ("checks", vo.checks.asJson),
+          ("events", vo.getEvents.asJson)
+        )
+      case vp: ValidatorParquetFile =>
+        Json.obj(
+          ("parquetFile", Json.fromString(vp.parquetFile)),
+          ("failed", vp.failed.asJson),
+          ("keyColumns", vp.keyColumns.asJson),
+          ("checks", vp.checks.asJson),
+          ("events", vp.getEvents.asJson)
+        )
+      case vdf: ValidatorDataFrame =>
+        Json.obj(
+          ("dfLabel", vdf.label.asJson),
+          ("failed", vdf.failed.asJson),
+          ("keyColumns", vdf.keyColumns.asJson),
+          ("checks", vdf.checks.asJson),
+          ("events", vdf.getEvents.asJson)
+        )
+      case vcf: ValidatorSpecifiedFormatLoader =>
+        Json.obj(
+          ("format", Json.fromString(vcf.format)),
+          ("options", vcf.options.asJson),
+          ("loadData", vcf.loadData.asJson),
+          ("failed", vcf.failed.asJson),
+          ("keyColumns", vcf.keyColumns.asJson),
+          ("checks", vcf.checks.asJson),
+          ("events", vcf.getEvents.asJson)
+        )
     }
   }
 
   implicit val configVarEncoder: Encoder[ConfigVar] = new Encoder[ConfigVar] {
     override def apply(a: ConfigVar): Json = a match {
-      case nv: NameValue => Json.obj(
-        ("name", Json.fromString(nv.name)),
-        ("value", nv.value)
-      )
-      case ne: NameEnv => Json.obj(
-        ("name", Json.fromString(ne.name)),
-        ("env", Json.fromString(ne.env))
-      )
-      case nshell: NameShell => Json.obj(
-        ("name", Json.fromString(nshell.name)),
-        ("shell", Json.fromString(nshell.shell))
-      )
-      case nsql: NameSql => Json.obj(
-        ("name", Json.fromString(nsql.name)),
-        ("shell", Json.fromString(nsql.sql))
-      )
+      case nv: NameValue =>
+        Json.obj(
+          ("name", Json.fromString(nv.name)),
+          ("value", nv.value)
+        )
+      case ne: NameEnv =>
+        Json.obj(
+          ("name", Json.fromString(ne.name)),
+          ("env", Json.fromString(ne.env))
+        )
+      case nshell: NameShell =>
+        Json.obj(
+          ("name", Json.fromString(nshell.name)),
+          ("shell", Json.fromString(nshell.shell))
+        )
+      case nsql: NameSql =>
+        Json.obj(
+          ("name", Json.fromString(nsql.name)),
+          ("shell", Json.fromString(nsql.sql))
+        )
       case x =>
         logger.error(s"Unknown configVar type: $x")
         throw new RuntimeException(s"Unknown configVar type: $x")
@@ -147,14 +168,16 @@ object JsonEncoders extends LazyLogging {
   implicit val configOutputEncoder: Encoder[ValidatorOutput] = new Encoder[ValidatorOutput] {
     override def apply(a: ValidatorOutput): Json = a match {
 
-      case file: FileOutput => Json.obj(
-        ("filename", Json.fromString(file.filename)),
-        ("append", Json.fromBoolean(file.append.getOrElse(false)))
-      )
-      case pipe: PipeOutput => Json.obj(
-        ("pipe", Json.fromString(pipe.pipe)),
-        ("ignoreError", Json.fromBoolean(pipe.ignoreError.getOrElse(false)))
-      )
+      case file: FileOutput =>
+        Json.obj(
+          ("filename", Json.fromString(file.filename)),
+          ("append", Json.fromBoolean(file.append.getOrElse(false)))
+        )
+      case pipe: PipeOutput =>
+        Json.obj(
+          ("pipe", Json.fromString(pipe.pipe)),
+          ("ignoreError", Json.fromBoolean(pipe.ignoreError.getOrElse(false)))
+        )
       case x =>
         logger.error(s"Unknown output type: $x")
         throw new RuntimeException(s"Unknown output type: $x")

--- a/src/main/scala/com/target/data_validator/JsonUtils.scala
+++ b/src/main/scala/com/target/data_validator/JsonUtils.scala
@@ -23,20 +23,20 @@ object JsonUtils extends LazyLogging {
     case _ => s"Json UNKNOWN[${j.getClass.getSimpleName}]: ${j.noSpaces}"
   }
 
-  /**
-    * Turn Row into JSon
-    * @return Json Object
+  /** Turn Row into JSon
+    * @return
+    *   Json Object
     */
   def row2Json(row: Row): Json = {
-    val fields = row.schema.fieldNames.zipWithIndex.map {
-      case (fieldName, idx) => (fieldName, row2Json(row, idx))
+    val fields = row.schema.fieldNames.zipWithIndex.map { case (fieldName, idx) =>
+      (fieldName, row2Json(row, idx))
     }
     Json.obj(fields: _*)
   }
 
-  /**
-    * Take Row, and turn col into Json.
-    * @return Json
+  /** Take Row, and turn col into Json.
+    * @return
+    *   Json
     */
   def row2Json(row: Row, col: Int): Json = {
     val dataType = row.schema(col).dataType
@@ -49,8 +49,10 @@ object JsonUtils extends LazyLogging {
       case DoubleType => Json.fromDoubleOrNull(row.getDouble(col))
       case _: StructType => row2Json(row.getStruct(col))
       case _ =>
-        logger.error(s"Unimplemented dataType '${dataType.typeName}' in column: ${row.schema(col).name} " +
-          "Please report this as a bug.")
+        logger.error(
+          s"Unimplemented dataType '${dataType.typeName}' in column: ${row.schema(col).name} " +
+            "Please report this as a bug."
+        )
         Json.Null
     }
   }

--- a/src/main/scala/com/target/data_validator/Reports.scala
+++ b/src/main/scala/com/target/data_validator/Reports.scala
@@ -6,9 +6,9 @@ import org.apache.spark.sql.SparkSession
 object Reports extends LazyLogging with EventLog {
 
   def emailReport(
-                   mainConfig: CliOptions,
-                   config: ValidatorConfig,
-                   varSub: VarSubstitution
+      mainConfig: CliOptions,
+      config: ValidatorConfig,
+      varSub: VarSubstitution
   )(implicit spark: SparkSession): Unit = {
     if (mainConfig.htmlReport.isDefined || config.email.isDefined) {
       val htmlReport = config.generateHTMLReport()
@@ -26,9 +26,9 @@ object Reports extends LazyLogging with EventLog {
   }
 
   def jsonReport(
-                  mainConfig: CliOptions,
-                  config: ValidatorConfig,
-                  varSub: VarSubstitution
+      mainConfig: CliOptions,
+      config: ValidatorConfig,
+      varSub: VarSubstitution
   )(implicit spark: SparkSession): Unit = {
     if (config.outputs.isDefined || mainConfig.jsonReport.isDefined) {
       val jsonReport = config.genJsonReport(varSub)
@@ -37,7 +37,10 @@ object Reports extends LazyLogging with EventLog {
         IO.writeJSON(jsonFilename, jsonReport, append = true)
       }
 
-      for (outputs <- config.outputs; out <- outputs) {
+      for {
+        outputs <- config.outputs
+        out <- outputs
+      } {
         if (out.write(jsonReport)) {
           val msg = s"ERROR: Failed to write out: $out"
           logger.error(msg)

--- a/src/main/scala/com/target/data_validator/ValidatorConfig.scala
+++ b/src/main/scala/com/target/data_validator/ValidatorConfig.scala
@@ -14,13 +14,13 @@ import scala.util.Try
 import scalatags.Text.all._
 
 case class ValidatorConfig(
-  numKeyCols: Int,
-  numErrorsToReport: Int,
-  email: Option[EmailConfig],
-  detailedErrors: Boolean = true,
-  vars: Option[List[ConfigVar]],
-  outputs: Option[List[ValidatorOutput]],
-  tables: List[ValidatorTable]
+    numKeyCols: Int,
+    numErrorsToReport: Int,
+    email: Option[EmailConfig],
+    detailedErrors: Boolean = true,
+    vars: Option[List[ConfigVar]],
+    outputs: Option[List[ValidatorOutput]],
+    tables: List[ValidatorTable]
 ) extends LazyLogging {
 
   def failed: Boolean = tables.exists(_.failed)
@@ -61,9 +61,13 @@ case class ValidatorConfig(
 
   def substituteVariables(varSub: VarSubstitution): Option[ValidatorConfig] = {
     logger.info("substituteVariables()")
-    Some(this.copy(email = this.email.map(_.substituteVariables(varSub)),
-      tables = this.tables.map(_.substituteVariables(varSub)),
-      outputs = this.outputs.map(_.map(_.substituteVariables(varSub)))))
+    Some(
+      this.copy(
+        email = this.email.map(_.substituteVariables(varSub)),
+        tables = this.tables.map(_.substituteVariables(varSub)),
+        outputs = this.outputs.map(_.map(_.substituteVariables(varSub)))
+      )
+    )
   }
 
   def genJsonReport(varSub: VarSubstitution)(implicit spark: SparkSession): Json = {

--- a/src/main/scala/com/target/data_validator/ValidatorEvent.scala
+++ b/src/main/scala/com/target/data_validator/ValidatorEvent.scala
@@ -17,34 +17,35 @@ trait ValidatorEvent {
 case class ValidatorCounter(name: String, value: Long) extends ValidatorEvent {
   override def failed: Boolean = false
   override def toHTML: Tag = {
-    div(cls:="counter")(s"Counter - $name: $value")
+    div(cls := "counter")(s"Counter - $name: $value")
   }
 }
 
 case class ValidatorError(msg: String) extends ValidatorEvent {
   override def failed: Boolean = true
 
-  override def toHTML: Text.all.Tag = div(cls:="error")(failedHTML, msg)
+  override def toHTML: Text.all.Tag = div(cls := "error")(failedHTML, msg)
 }
 
-case class ValidatorCheckEvent(failure: Boolean, label: String, count: Long, errorCount: Long) extends ValidatorEvent {
+case class ValidatorCheckEvent(failure: Boolean, label: String, count: Long, errorCount: Long)
+    extends ValidatorEvent {
   override def failed: Boolean = failure
 
   override def toHTML: Text.all.Tag = {
     val pct = "%4.2f%%".format((errorCount * 100.0) / count)
-    div(cls:="checkEvent")(failedHTML, s" - $label count: $count errors: $errorCount pct: $pct")
+    div(cls := "checkEvent")(failedHTML, s" - $label count: $count errors: $errorCount pct: $pct")
   }
 }
 
 case class ColumnBasedValidatorCheckEvent(
-  failure: Boolean,
-  data: Map[String, String],
-  msg: String
+    failure: Boolean,
+    data: Map[String, String],
+    msg: String
 ) extends ValidatorEvent {
   override def failed: Boolean = failure
 
   override def toHTML: Text.all.Tag = {
-    div(cls:="checkEvent")(failedHTML, s" - $msg")
+    div(cls := "checkEvent")(failedHTML, s" - $msg")
   }
 }
 
@@ -55,24 +56,25 @@ class ValidatorTimer(val label: String) extends ValidatorEvent {
 
   def time[R](block: => R): R = {
     val start = System.nanoTime()
-    val result = try {
-      block
-    } finally {
-      duration = System.nanoTime() - start
-    }
+    val result =
+      try {
+        block
+      } finally {
+        duration = System.nanoTime() - start
+      }
     result
   }
 
   def toSecs: Long = TimeUnit.SECONDS.convert(duration, TimeUnit.NANOSECONDS)
 
-  override def toHTML: Text.all.Tag = div(cls:="timer")(s"Timer: $label took $toSecs seconds.")
+  override def toHTML: Text.all.Tag = div(cls := "timer")(s"Timer: $label took $toSecs seconds.")
 
   override def toString: String = s"Time: $label Duration: $toSecs seconds"
 }
 
 case class ValidatorQuickCheckError(key: List[(String, Any)], value: Any, message: String) extends ValidatorEvent {
   override def failed: Boolean = true
-  override def toHTML: Text.all.Tag = div(cls:="quickCheckError")(failedHTML, " - " + toString)
+  override def toHTML: Text.all.Tag = div(cls := "quickCheckError")(failedHTML, " - " + toString)
 
   def keyToString: String = "{" + key.map { case (c, v) => s"$c:$v" }.mkString(", ") + "}"
 
@@ -85,19 +87,19 @@ case class ValidatorQuickCheckError(key: List[(String, Any)], value: Any, messag
 case class ValidatorGood(msg: String) extends ValidatorEvent {
   override def failed: Boolean = false
   override def toString: String = msg
-  override def toHTML: Text.all.Tag = div(cls:="good")(msg)
+  override def toHTML: Text.all.Tag = div(cls := "good")(msg)
 }
 
 case class VarSubEvent(src: String, dest: String) extends ValidatorEvent {
   override def failed: Boolean = false
   override def toString: String = s"VarSub src: $src dest: $dest"
-  override def toHTML: Text.all.Tag = div(cls:="subEvent")(toString)
+  override def toHTML: Text.all.Tag = div(cls := "subEvent")(toString)
 }
 
 case class VarSubJsonEvent(src: String, dest: Json) extends ValidatorEvent {
   override def failed: Boolean = false
   override def toString: String = s"VarSub src: $src dest: ${dest.noSpaces}"
-  override def toHTML: Text.all.Tag = div(cls:="subEvent")(toString)
+  override def toHTML: Text.all.Tag = div(cls := "subEvent")(toString)
 }
 
 case class JsonEvent(json: Json) extends ValidatorEvent {

--- a/src/main/scala/com/target/data_validator/VarSubstitution.scala
+++ b/src/main/scala/com/target/data_validator/VarSubstitution.scala
@@ -12,12 +12,14 @@ class VarSubstitution() extends LazyLogging {
 
   val dict = new mutable.HashMap[String, Json]()
 
-  /**
-    * Adds (k,v) to dictionary.
+  /** Adds (k,v) to dictionary.
     *
-    * @param key - key of value in dictionary.
-    * @param value - value of key in dictionary.
-    * @return True on error.
+    * @param key
+    *   \- key of value in dictionary.
+    * @param value
+    *   \- value of key in dictionary.
+    * @return
+    *   True on error.
     */
   def add(key: String, value: Json): Boolean = {
     if (VAR_REGEX.findFirstIn(key).isEmpty) {
@@ -37,10 +39,11 @@ class VarSubstitution() extends LazyLogging {
     }
   }
 
-  /**
-    * Adds a String to dictionary.
-    * @param value - gets converted to Json
-    * @return True on error
+  /** Adds a String to dictionary.
+    * @param value
+    *   \- gets converted to Json
+    * @return
+    *   True on error
     */
   def addString(key: String, value: String): Boolean = {
     replaceVars(value) match {
@@ -49,11 +52,12 @@ class VarSubstitution() extends LazyLogging {
     }
   }
 
-  /**
-    * Removes key from dictionary.
+  /** Removes key from dictionary.
     *
-    * @param k - key to  be removed.
-    * @return True on error.
+    * @param k
+    *   \- key to be removed.
+    * @return
+    *   True on error.
     */
   def remove(k: String): Boolean = {
     if (dict.contains(k)) {
@@ -65,11 +69,12 @@ class VarSubstitution() extends LazyLogging {
     }
   }
 
-  /**
-    * replaces variables in String.
+  /** replaces variables in String.
     *
-    * @param s - string to replace variables in.
-    * @return Left(new string) on Success, Right(ValidatorEvent) on Error
+    * @param s
+    *   \- string to replace variables in.
+    * @return
+    *   Left(new string) on Success, Right(ValidatorEvent) on Error
     */
   def replaceVars(s: String): Either[String, ValidatorEvent] = {
     val variableJson = findVars(s).toSeq.map(x => (x, getVarName(x).flatMap(dict.get)))
@@ -87,8 +92,12 @@ class VarSubstitution() extends LazyLogging {
     val errs = missingVariableJson.map(x => x._1)
     errs.foreach(x => logger.debug(s"errs: $x"))
     if (errs.nonEmpty) {
-      Right(ValidatorError("VariableSubstitution: Can't find values for the following keys, " +
-        s"${errs.flatMap(getVarName).mkString(",")}"))
+      Right(
+        ValidatorError(
+          "VariableSubstitution: Can't find values for the following keys, " +
+            s"${errs.flatMap(getVarName).mkString(",")}"
+        )
+      )
     } else {
       if (s != newString) {
         logger.debug(s"Replaced '$s' with '$newString'")
@@ -119,14 +128,12 @@ class VarSubstitution() extends LazyLogging {
     if (dict.contains(k)) logger.warn(s"Replacing key: $k old: ${dict(k)} with new: $v")
   }
 
-  /**
-    * Adds the map m to dict
+  /** Adds the map m to dict
     */
   def addMap(m: Map[String, String]): Unit = {
-    val kj = m.map {
-      case (k, v) =>
-        logDupKeys(k, v)
-        (k, JsonUtils.string2Json(v))
+    val kj = m.map { case (k, v) =>
+      logDupKeys(k, v)
+      (k, JsonUtils.string2Json(v))
     }
     dict ++= kj
   }
@@ -146,20 +153,24 @@ object VarSubstitution extends LazyLogging {
     VAR_BODY_REGEX.findAllIn(s).toSet
   }
 
-  /**
-    * Checks if s is a variable.
-    * @param s - string to check
-    * @return true if s is a variable.
+  /** Checks if s is a variable.
+    * @param s
+    *   \- string to check
+    * @return
+    *   true if s is a variable.
     */
   def isVariable(s: String): Boolean = s.startsWith("$") && VAR_BODY_REGEX.findFirstMatchIn(s).isDefined
 
-  /**
-    * Replaces all the occurrences of oldVal in src with newVal.
+  /** Replaces all the occurrences of oldVal in src with newVal.
     *
-    * @param src - source string that contains values to be replaced.
-    * @param oldVal - old Value that will be replaced by newValue.
-    * @param newVal - new Value that will replace oldValue.
-    * @return new string with newVal were oldVal was.
+    * @param src
+    *   \- source string that contains values to be replaced.
+    * @param oldVal
+    *   \- old Value that will be replaced by newValue.
+    * @param newVal
+    *   \- new Value that will replace oldValue.
+    * @return
+    *   new string with newVal were oldVal was.
     */
   def replaceAll(src: String, oldVal: String, newVal: String): String = {
     val buf = new StringBuffer(src)
@@ -173,11 +184,12 @@ object VarSubstitution extends LazyLogging {
     ret
   }
 
-  /**
-    * gets the variable name from the variable. ie "$\{foo\}" returns "foo"
+  /** gets the variable name from the variable. ie "$\{foo\}" returns "foo"
     *
-    * @param rawVar - variable with control chars.
-    * @return variable without '$' or '{','}'
+    * @param rawVar
+    *   \- variable with control chars.
+    * @return
+    *   variable without '$' or '{','}'
     */
   def getVarName(rawVar: String): Option[String] = {
     val ret = if (rawVar.startsWith("${")) {

--- a/src/main/scala/com/target/data_validator/stats/CompleteStats.scala
+++ b/src/main/scala/com/target/data_validator/stats/CompleteStats.scala
@@ -4,14 +4,14 @@ import io.circe._
 import io.circe.generic.semiauto._
 
 case class CompleteStats(
-  name: String,
-  column: String,
-  count: Long,
-  mean: Double,
-  min: Double,
-  max: Double,
-  stdDev: Double,
-  histogram: Histogram
+    name: String,
+    column: String,
+    count: Long,
+    mean: Double,
+    min: Double,
+    max: Double,
+    stdDev: Double,
+    histogram: Histogram
 )
 
 object CompleteStats {
@@ -24,10 +24,10 @@ object CompleteStats {
   implicit val decoder: Decoder[CompleteStats] = deriveDecoder
 
   def apply(
-    name: String,
-    column: String,
-    firstPassStats: FirstPassStats,
-    secondPassStats: SecondPassStats
+      name: String,
+      column: String,
+      firstPassStats: FirstPassStats,
+      secondPassStats: SecondPassStats
   ): CompleteStats = CompleteStats(
     name = name,
     column = column,

--- a/src/main/scala/com/target/data_validator/stats/FirstPassStats.scala
+++ b/src/main/scala/com/target/data_validator/stats/FirstPassStats.scala
@@ -11,11 +11,12 @@ object FirstPassStats {
     .schemaFor[FirstPassStats]
     .dataType
 
-  /**
-    * Convert from Spark SQL row format to case class [[FirstPassStats]] format.
+  /** Convert from Spark SQL row format to case class [[FirstPassStats]] format.
     *
-    * @param row a complex column of [[org.apache.spark.sql.types.StructType]] output of [[FirstPassStatsAggregator]]
-    * @return struct format converted to [[FirstPassStats]]
+    * @param row
+    *   a complex column of [[org.apache.spark.sql.types.StructType]] output of [[FirstPassStatsAggregator]]
+    * @return
+    *   struct format converted to [[FirstPassStats]]
     */
   def fromRowRepr(row: Row): FirstPassStats = {
     FirstPassStats(

--- a/src/main/scala/com/target/data_validator/stats/FirstPassStatsAggregator.scala
+++ b/src/main/scala/com/target/data_validator/stats/FirstPassStatsAggregator.scala
@@ -4,18 +4,15 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
 import org.apache.spark.sql.types._
 
-/**
-  * Calculate the count, mean, min and maximum values of a numeric column.
+/** Calculate the count, mean, min and maximum values of a numeric column.
   */
 class FirstPassStatsAggregator extends UserDefinedAggregateFunction {
 
-  /**
-    * input is a single column of `DoubleType`
+  /** input is a single column of `DoubleType`
     */
   override def inputSchema: StructType = new StructType().add("value", DoubleType)
 
-  /**
-    * buffer keeps state for the count, sum, min and max
+  /** buffer keeps state for the count, sum, min and max
     */
   override def bufferSchema: StructType = new StructType()
     .add(StructField("count", LongType))
@@ -28,18 +25,15 @@ class FirstPassStatsAggregator extends UserDefinedAggregateFunction {
   private val min = bufferSchema.fieldIndex("min")
   private val max = bufferSchema.fieldIndex("max")
 
-  /**
-    * specifies the return type when using the UDAF
+  /** specifies the return type when using the UDAF
     */
   override def dataType: DataType = FirstPassStats.dataType
 
-  /**
-    * These calculations are deterministic
+  /** These calculations are deterministic
     */
   override def deterministic: Boolean = true
 
-  /**
-    * set the initial values for count, sum, min and max
+  /** set the initial values for count, sum, min and max
     */
   override def initialize(buffer: MutableAggregationBuffer): Unit = {
     buffer(count) = 0L
@@ -48,8 +42,7 @@ class FirstPassStatsAggregator extends UserDefinedAggregateFunction {
     buffer(max) = Double.MinValue
   }
 
-  /**
-    * update the count, sum, min and max buffer values
+  /** update the count, sum, min and max buffer values
     */
   override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
     buffer(count) = buffer.getLong(count) + 1
@@ -58,8 +51,7 @@ class FirstPassStatsAggregator extends UserDefinedAggregateFunction {
     buffer(max) = math.max(input.getDouble(0), buffer.getDouble(max))
   }
 
-  /**
-    * reduce the count, sum, min and max values of two buffers
+  /** reduce the count, sum, min and max values of two buffers
     */
   override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
     buffer1(count) = buffer1.getLong(count) + buffer2.getLong(count)
@@ -68,8 +60,7 @@ class FirstPassStatsAggregator extends UserDefinedAggregateFunction {
     buffer1(max) = math.max(buffer1.getDouble(max), buffer2.getDouble(max))
   }
 
-  /**
-    * evaluate the count, mean, min and max values of a column
+  /** evaluate the count, mean, min and max values of a column
     */
   override def evaluate(buffer: Row): Any = {
     FirstPassStats(

--- a/src/main/scala/com/target/data_validator/stats/SecondPassStats.scala
+++ b/src/main/scala/com/target/data_validator/stats/SecondPassStats.scala
@@ -11,18 +11,19 @@ object SecondPassStats {
     .schemaFor[SecondPassStats]
     .dataType
 
-  /**
-    * Convert from Spark SQL row format to case class [[SecondPassStats]] format.
+  /** Convert from Spark SQL row format to case class [[SecondPassStats]] format.
     *
-    * @param row a complex column of [[org.apache.spark.sql.types.StructType]] output of [[SecondPassStatsAggregator]]
-    * @return struct format converted to [[SecondPassStats]]
+    * @param row
+    *   a complex column of [[org.apache.spark.sql.types.StructType]] output of [[SecondPassStatsAggregator]]
+    * @return
+    *   struct format converted to [[SecondPassStats]]
     */
   def fromRowRepr(row: Row): SecondPassStats = {
     SecondPassStats(
       stdDev = row.getDouble(0),
       histogram = Histogram(
-        row.getStruct(1).getSeq[Row](0) map {
-          bin => Bin(
+        row.getStruct(1).getSeq[Row](0) map { bin =>
+          Bin(
             lowerBound = bin.getDouble(0),
             upperBound = bin.getDouble(1),
             count = bin.getLong(2)

--- a/src/main/scala/com/target/data_validator/stats/SecondPassStatsAggregator.scala
+++ b/src/main/scala/com/target/data_validator/stats/SecondPassStatsAggregator.scala
@@ -4,8 +4,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.expressions.{MutableAggregationBuffer, UserDefinedAggregateFunction}
 import org.apache.spark.sql.types._
 
-/**
-  * Calculate the standard deviation and histogram of a numeric column
+/** Calculate the standard deviation and histogram of a numeric column
   */
 class SecondPassStatsAggregator(firstPassStats: FirstPassStats) extends UserDefinedAggregateFunction {
 
@@ -14,13 +13,11 @@ class SecondPassStatsAggregator(firstPassStats: FirstPassStats) extends UserDefi
   private val binSize = (firstPassStats.max - firstPassStats.min) / NUMBER_OF_BINS
   private val upperBounds = for (i <- 1 to NUMBER_OF_BINS) yield { firstPassStats.min + i * binSize }
 
-  /**
-    * input is a single column of `DoubleType`
+  /** input is a single column of `DoubleType`
     */
   override def inputSchema: StructType = new StructType().add("value", DoubleType)
 
-  /**
-    * buffer keeps state for the total count, sumOfSquares, and individual bin counts
+  /** buffer keeps state for the total count, sumOfSquares, and individual bin counts
     */
   override def bufferSchema: StructType = StructType(
     List(
@@ -44,18 +41,15 @@ class SecondPassStatsAggregator(firstPassStats: FirstPassStats) extends UserDefi
   private val binStart = bufferSchema.fieldIndex("bin1count")
   private val binEnd = bufferSchema.fieldIndex("bin10count")
 
-  /**
-    * specifies the return type when using the UDAF
+  /** specifies the return type when using the UDAF
     */
   override def dataType: DataType = SecondPassStats.dataType
 
-  /**
-    * these calculations are deterministic
+  /** these calculations are deterministic
     */
   override def deterministic: Boolean = true
 
-  /**
-    * set the initial values for count, sum of squares and individual bin counts
+  /** set the initial values for count, sum of squares and individual bin counts
     */
   override def initialize(buffer: MutableAggregationBuffer): Unit = {
     buffer(count) = 0L
@@ -63,8 +57,7 @@ class SecondPassStatsAggregator(firstPassStats: FirstPassStats) extends UserDefi
     for (i <- binStart to binEnd) { buffer(i) = 0L }
   }
 
-  /**
-    * update the count, sum of squares and individual bin counts
+  /** update the count, sum of squares and individual bin counts
     */
   override def update(buffer: MutableAggregationBuffer, input: Row): Unit = {
     buffer(count) = buffer.getLong(count) + 1
@@ -75,8 +68,7 @@ class SecondPassStatsAggregator(firstPassStats: FirstPassStats) extends UserDefi
     buffer(binIndex) = buffer.getLong(binIndex) + 1
   }
 
-  /**
-    * reduce the count, sum of squares and individual bin counts
+  /** reduce the count, sum of squares and individual bin counts
     */
   override def merge(buffer1: MutableAggregationBuffer, buffer2: Row): Unit = {
     buffer1(count) = buffer1.getLong(count) + buffer2.getLong(count)
@@ -86,8 +78,7 @@ class SecondPassStatsAggregator(firstPassStats: FirstPassStats) extends UserDefi
     }
   }
 
-  /**
-    * evaluate the standard deviation and define bins of histogram
+  /** evaluate the standard deviation and define bins of histogram
     */
   override def evaluate(buffer: Row): Any = {
     val bins: Seq[Bin] = for (i <- binStart to binEnd) yield {

--- a/src/main/scala/com/target/data_validator/validator/ColStats.scala
+++ b/src/main/scala/com/target/data_validator/validator/ColStats.scala
@@ -15,11 +15,11 @@ import org.apache.spark.sql.types.{NumericType, StructType}
 import scala.concurrent.Promise
 import scala.util._
 
-/**
-  * This validator implements a set of column metrics on a specified column by performing two I/O
-  *  passes over the input table.
+/** This validator implements a set of column metrics on a specified column by performing two I/O passes over the
+  * input table.
   *
-  * @param column the column to collect stats on
+  * @param column
+  *   the column to collect stats on
   */
 final case class ColStats(column: String) extends TwoPassCheapCheck {
   import ValidatorBase._

--- a/src/main/scala/com/target/data_validator/validator/ColumnBased.scala
+++ b/src/main/scala/com/target/data_validator/validator/ColumnBased.scala
@@ -24,11 +24,9 @@ abstract class ColumnBased(column: String, condTest: Expression) extends CheapCh
 
     if (expected == actual) {
       formatStr.format(0.00) // if expected == actual, error % should be 0, even if expected is 0
-    }
-    else if (expected == 0.0) {
+    } else if (expected == 0.0) {
       "undefined"
-    }
-    else {
+    } else {
       val pct = abs(((expected - actual) * 100.0) / expected)
       formatStr.format(pct)
     }
@@ -53,10 +51,11 @@ case class MinNumRows(minNumRows: Json) extends ColumnBased("", ValidatorBase.L0
     }
 
     minNumRows.asNumber match {
-      case Some(jsonNumber) => jsonNumber.toLong match {
-        case Some(x) if x > 0 =>
-        case _ => notNaturalNumber()
-      }
+      case Some(jsonNumber) =>
+        jsonNumber.toLong match {
+          case Some(x) if x > 0 =>
+          case _ => notNaturalNumber()
+        }
       case _ => notNaturalNumber()
     }
     failed
@@ -87,7 +86,7 @@ case class MinNumRows(minNumRows: Json) extends ColumnBased("", ValidatorBase.L0
 }
 
 case class ColumnMaxCheck(column: String, value: Json)
-  extends ColumnBased(column, Max(UnresolvedAttribute(column)).toAggregateExpression()) {
+    extends ColumnBased(column, Max(UnresolvedAttribute(column)).toAggregateExpression()) {
 
   override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
     val ret = copy(column = getVarSub(column, "column", dict), value = getVarSubJson(value, "value", dict))
@@ -136,7 +135,7 @@ case class ColumnMaxCheck(column: String, value: Json)
     def resultForOther: (ListMap[String, String], String) = {
       logger.error(
         s"""ColumnMaxCheck for type: $dataType, Row: $row not implemented!
-           |Please open a bug report on the data-validator issue tracker.""".stripMargin
+          |Please open a bug report on the data-validator issue tracker.""".stripMargin
       )
       failed = true
       val errorMsg = s"ColumnMaxCheck is not supported for data type $dataType"

--- a/src/main/scala/com/target/data_validator/validator/ColumnSumCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/ColumnSumCheck.scala
@@ -12,17 +12,17 @@ import org.apache.spark.sql.types._
 import scala.collection.immutable.ListMap
 
 case class ColumnSumCheck(
-  column: String,
-  minValue: Option[Json] = None,
-  maxValue: Option[Json] = None,
-  inclusive: Option[Json] = None
+    column: String,
+    minValue: Option[Json] = None,
+    maxValue: Option[Json] = None,
+    inclusive: Option[Json] = None
 ) extends ColumnBased(column, Sum(UnresolvedAttribute(column)).toAggregateExpression()) {
 
   private val minOrMax: Either[String, Unit] = if (minValue.isEmpty && maxValue.isEmpty) {
-      Left("'minValue' or 'maxValue' or both must be defined")
-    } else {
-      Right()
-    }
+    Left("'minValue' or 'maxValue' or both must be defined")
+  } else {
+    Right()
+  }
 
   private val lowerBound: Either[String, Double] = minValue match {
     case Some(json) =>
@@ -61,21 +61,18 @@ case class ColumnSumCheck(
     val upperBoundValue = upperBound.right.get
 
     def evaluate(sum: Double): Boolean = {
-      if (isInclusive) { sum > upperBoundValue || sum < lowerBoundValue}
-      else { sum >= upperBoundValue || sum <= lowerBoundValue}
+      if (isInclusive) { sum > upperBoundValue || sum < lowerBoundValue }
+      else { sum >= upperBoundValue || sum <= lowerBoundValue }
     }
 
     def getPctError(sum: Double): String = {
       if (sum < lowerBoundValue) {
         calculatePctError(lowerBoundValue, sum)
-      }
-      else if (sum > upperBoundValue) {
+      } else if (sum > upperBoundValue) {
         calculatePctError(upperBoundValue, sum)
-      }
-      else if (!isInclusive && (sum == upperBoundValue || sum == lowerBoundValue)) {
+      } else if (!isInclusive && (sum == upperBoundValue || sum == lowerBoundValue)) {
         "undefined"
-      }
-      else {
+      } else {
         "0.00%"
       }
     }
@@ -111,7 +108,8 @@ case class ColumnSumCheck(
       bounds.mkString("(", ", ", ")")
     }
 
-    val msg = s"$name on $column[$dataType]: Expected Range: $prettyBounds Actual: ${r(idx)} Relative Error: $pctError"
+    val msg =
+      s"$name on $column[$dataType]: Expected Range: $prettyBounds Actual: ${r(idx)} Relative Error: $pctError"
     addEvent(ColumnBasedValidatorCheckEvent(failed, data, msg))
     failed
   }
@@ -158,11 +156,13 @@ case class ColumnSumCheck(
 
   override def toJson: Json = {
     import JsonEncoders.eventEncoder
-    val additionalFieldsForReport = Json.fromFields(Set(
-      "type" -> Json.fromString("columnSumCheck"),
-      "failed" -> Json.fromBoolean(failed),
-      "events" -> getEvents.asJson
-    ))
+    val additionalFieldsForReport = Json.fromFields(
+      Set(
+        "type" -> Json.fromString("columnSumCheck"),
+        "failed" -> Json.fromBoolean(failed),
+        "events" -> getEvents.asJson
+      )
+    )
 
     val base = ColumnSumCheck.encoder(this)
     base.deepMerge(additionalFieldsForReport)

--- a/src/main/scala/com/target/data_validator/validator/JsonDecoders.scala
+++ b/src/main/scala/com/target/data_validator/validator/JsonDecoders.scala
@@ -29,8 +29,7 @@ object JsonDecoders extends LazyLogging {
     private def getDecoder(cursor: HCursor)(checkType: String) = {
       decoders
         .get(checkType)
-        .map(_(cursor))
-      match {
+        .map(_(cursor)) match {
         case Some(x) => x
         case None =>
           logger.error(s"Unknown Check `$checkType` in config! Choose one of: ${decoders.keys.mkString(", ")}.")

--- a/src/main/scala/com/target/data_validator/validator/NegativeCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/NegativeCheck.scala
@@ -14,8 +14,7 @@ import org.apache.spark.sql.types.{NumericType, StructType}
 case class NegativeCheck(column: String, threshold: Option[String]) extends RowBased {
 
   override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
-    val ret = NegativeCheck(getVarSub(column, "column", dict),
-      threshold.map(getVarSub(_, "threshold", dict)))
+    val ret = NegativeCheck(getVarSub(column, "column", dict), threshold.map(getVarSub(_, "threshold", dict)))
     getEvents.foreach(ret.addEvent)
     ret
   }
@@ -37,7 +36,7 @@ case class NegativeCheck(column: String, threshold: Option[String]) extends RowB
   }
 
   override def colTest(schema: StructType, dict: VarSubstitution): Expression =
-    LessThan (UnresolvedAttribute(column), I0)
+    LessThan(UnresolvedAttribute(column), I0)
 
   override def toJson: Json = Json.obj(
     ("type", Json.fromString("negativeCheck")),

--- a/src/main/scala/com/target/data_validator/validator/NullCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/NullCheck.scala
@@ -12,8 +12,7 @@ import org.apache.spark.sql.types.StructType
 case class NullCheck(column: String, threshold: Option[String]) extends RowBased {
 
   override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
-    val ret = NullCheck(getVarSub(column, "column", dict),
-      threshold.map(getVarSub(_, "threshold", dict)))
+    val ret = NullCheck(getVarSub(column, "column", dict), threshold.map(getVarSub(_, "threshold", dict)))
     getEvents.foreach(ret.addEvent)
     ret
   }

--- a/src/main/scala/com/target/data_validator/validator/RangeCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/RangeCheck.scala
@@ -12,11 +12,12 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{DataType, StructType}
 
 case class RangeCheck(
-  column: String,
-  minValue: Option[Json],
-  maxValue: Option[Json],
-  inclusive: Option[Json],
-  threshold: Option[String]) extends RowBased {
+    column: String,
+    minValue: Option[Json],
+    maxValue: Option[Json],
+    inclusive: Option[Json],
+    threshold: Option[String]
+) extends RowBased {
 
   override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
     val ret = RangeCheck(
@@ -24,16 +25,17 @@ case class RangeCheck(
       minValue.map(getVarSubJson(_, "minValue", dict)),
       maxValue.map(getVarSubJson(_, "maxValue", dict)),
       inclusive.map(getVarSubJson(_, "inclusive", dict)),
-      threshold.map(getVarSub(_, "threshold", dict)))
+      threshold.map(getVarSub(_, "threshold", dict))
+    )
     getEvents.foreach(ret.addEvent)
     ret
   }
 
   private def cmpExpr(
-    colExpr: Expression,
-    value: Option[Json],
-    colType: DataType,
-    cmp: (Expression, Expression) => Expression
+      colExpr: Expression,
+      value: Option[Json],
+      colType: DataType,
+      cmp: (Expression, Expression) => Expression
   ): Option[Expression] = {
     value.map { v => cmp(colExpr, createLiteralOrUnresolvedAttribute(colType, v)) }
   }
@@ -82,7 +84,7 @@ case class RangeCheck(
 
   override def configCheck(df: DataFrame): Boolean = {
 
-    val values = (minValue::maxValue::Nil).flatten
+    val values = (minValue :: maxValue :: Nil).flatten
     if (values.isEmpty) {
       addEvent(ValidatorError("Must defined minValue or maxValue or both."))
     }
@@ -136,7 +138,7 @@ object RangeCheck extends LazyLogging {
     logger.debug(s"inclusive: $inclusiveJ type: ${inclusiveJ.getClass.getCanonicalName}")
     logger.debug(s"threshold: $threshold")
 
-    c.focus.foreach {f => logger.debug(s"RangeCheckJson: ${f.spaces2}")}
+    c.focus.foreach { f => logger.debug(s"RangeCheckJson: ${f.spaces2}") }
     scala.util.Right(RangeCheck(column, minValueJ, maxValueJ, inclusiveJ, threshold))
   }
 }

--- a/src/main/scala/com/target/data_validator/validator/StringLengthCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/StringLengthCheck.scala
@@ -12,10 +12,10 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{IntegerType, StringType, StructType}
 
 case class StringLengthCheck(
-  column: String,
-  minLength: Option[Json],
-  maxLength: Option[Json],
-  threshold: Option[String]
+    column: String,
+    minLength: Option[Json],
+    maxLength: Option[Json],
+    threshold: Option[String]
 ) extends RowBased {
 
   override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
@@ -30,9 +30,10 @@ case class StringLengthCheck(
     ret
   }
 
-  private def cmpExpr(colExpr: Expression,
-    value: Option[Json],
-    cmp: (Expression, Expression) => Expression
+  private def cmpExpr(
+      colExpr: Expression,
+      value: Option[Json],
+      cmp: (Expression, Expression) => Expression
   ): Option[Expression] = {
     value.map { v => cmp(colExpr, createLiteralOrUnresolvedAttribute(IntegerType, v)) }
   }
@@ -77,7 +78,7 @@ case class StringLengthCheck(
   override def configCheck(df: DataFrame): Boolean = {
 
     // Verify if at least one of min or max is specified.
-    val values = (minLength::maxLength::Nil).flatten
+    val values = (minLength :: maxLength :: Nil).flatten
     if (values.isEmpty) {
       addEvent(ValidatorError("Must define minLength or maxLength or both."))
     }

--- a/src/main/scala/com/target/data_validator/validator/StringRegexCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/StringRegexCheck.scala
@@ -11,9 +11,9 @@ import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.types.{StringType, StructType}
 
 case class StringRegexCheck(
-  column: String,
-  regex: Option[Json],
-  threshold: Option[String]
+    column: String,
+    regex: Option[Json],
+    threshold: Option[String]
 ) extends RowBased {
 
   override def substituteVariables(dict: VarSubstitution): ValidatorBase = {
@@ -49,7 +49,7 @@ case class StringRegexCheck(
   override def configCheck(df: DataFrame): Boolean = {
 
     // Verify if regex is specified.
-    val values = (regex::Nil).flatten
+    val values = (regex :: Nil).flatten
     if (values.isEmpty) {
       addEvent(ValidatorError("Must define a regex."))
     }

--- a/src/main/scala/com/target/data_validator/validator/TwoPassCheapCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/TwoPassCheapCheck.scala
@@ -2,8 +2,7 @@ package com.target.data_validator.validator
 
 import org.apache.spark.sql._
 
-/**
-  * extension of [[CheapCheck]] with an assumption that DV will:
+/** extension of [[CheapCheck]] with an assumption that DV will:
   *   - complete a pre-pass stage that generates an intermediary aggregate
   *   - provide that intermediary aggregate so it can be used in generating the final check expression
   */
@@ -11,15 +10,12 @@ abstract class TwoPassCheapCheck extends CheapCheck {
 
   def hasQuickErrorDetails: Boolean = false
 
-  /**
-    * defined by implementor,
-    * should generate one row of aggregated output that can then be handled by [[sinkFirstPassRow]]
+  /** defined by implementor, should generate one row of aggregated output that can then be handled by
+    * [[sinkFirstPassRow]]
     */
   def firstPassSelect(): Column
 
-  /**
-    * defined by implementor,
-    * notify the cheap check of the result of the first pass projection
+  /** defined by implementor, notify the cheap check of the result of the first pass projection
     *
     * NOTE: the contract for this check type assumes you call this method BEFORE [[CheapCheck.select]]
     */

--- a/src/main/scala/com/target/data_validator/validator/UniqueCheck.scala
+++ b/src/main/scala/com/target/data_validator/validator/UniqueCheck.scala
@@ -25,7 +25,8 @@ case class UniqueCheck(columns: Seq[String]) extends CostlyCheck {
       ("type", Json.fromString("uniqueCheck")),
       ("columns", Json.fromValues(columns.map(Json.fromString))),
       ("failed", Json.fromBoolean(failed)),
-        ("events", this.getEvents.asJson))
+      ("events", this.getEvents.asJson)
+    )
 
     Json.fromFields(fields)
   }

--- a/src/main/scala/com/target/data_validator/validator/ValidatorBase.scala
+++ b/src/main/scala/com/target/data_validator/validator/ValidatorBase.scala
@@ -12,8 +12,8 @@ import scala.collection.mutable.ListBuffer
 import scalatags.Text.all._
 
 abstract class ValidatorBase(
-  var failed: Boolean = false,
-  events: ListBuffer[ValidatorEvent] = new ListBuffer[ValidatorEvent]
+    var failed: Boolean = false,
+    events: ListBuffer[ValidatorEvent] = new ListBuffer[ValidatorEvent]
 ) extends Substitutable {
   import ValidatorBase._
 
@@ -44,10 +44,11 @@ abstract class ValidatorBase(
 
   final def getEvents: List[ValidatorEvent] = events.toList
 
-  /**
-    * Check Types of column and value
-    * @param value - what we are comparing to from config.
-    * @return true on Error
+  /** Check Types of column and value
+    * @param value
+    *   \- what we are comparing to from config.
+    * @return
+    *   true on Error
     */
   private[validator] def checkTypes(df: DataFrame, column: String, value: Json): Boolean = {
     if (isColumnInDataFrame(df, column)) {
@@ -78,10 +79,10 @@ abstract class ValidatorBase(
   }
 
   private[validator] def checkValueString(
-    schema: StructType,
-    column: String,
-    colType: DataType,
-    value: String
+      schema: StructType,
+      column: String,
+      colType: DataType,
+      value: String
   ): Boolean = {
     val ret = if (isValueColumn(value)) {
       lookupValueColumn(schema, value) match {
@@ -107,19 +108,23 @@ abstract class ValidatorBase(
     ret
   }
 
-  /**
-    * Checks a value for compatibility with column.
-    * @param schema - from DataFrame.
-    * @param column - to check.
-    * @param colType - DataType of column.
-    * @param value - Json value to compare against column, could be another column.
-    * @return True on error.
+  /** Checks a value for compatibility with column.
+    * @param schema
+    *   \- from DataFrame.
+    * @param column
+    *   \- to check.
+    * @param colType
+    *   \- DataType of column.
+    * @param value
+    *   \- Json value to compare against column, could be another column.
+    * @return
+    *   True on error.
     */
   private[validator] def checkValue(
-    schema: StructType,
-    column: String,
-    colType: DataType,
-    value: Json
+      schema: StructType,
+      column: String,
+      colType: DataType,
+      value: Json
   ): Boolean = {
     val ret = value match {
       case v: Json if v.isNumber => !areNumberTypesCompatible(colType, v.asNumber)
@@ -153,27 +158,32 @@ object ValidatorBase extends LazyLogging {
     None
   }
 
-  /**
-    * searches for a columnName in schema
-    * @param schema - from source table.
-    * @param columnName - value from config that could be reference to column.
-    * @return True if v is found in schema.
+  /** searches for a columnName in schema
+    * @param schema
+    *   \- from source table.
+    * @param columnName
+    *   \- value from config that could be reference to column.
+    * @return
+    *   True if v is found in schema.
     */
   def schemaContainsValueColumn(schema: StructType, columnName: String): Boolean =
     lookupValueColumn(schema, columnName).isDefined
 
-  /**
-    * Take value that refers to a Column and creates an Expression referring to it.
-    * @param columnReference - String that is prefixes with backtick that represents a column name.
-    * @return UnresolvedAttribute
+  /** Take value that refers to a Column and creates an Expression referring to it.
+    * @param columnReference
+    *   \- String that is prefixes with backtick that represents a column name.
+    * @return
+    *   UnresolvedAttribute
     */
   def getValueColumn(columnReference: String): Expression = UnresolvedAttribute(columnReference.stripPrefix(backtick))
 
-  /**
-    * Takes Json Number and creates a Expression representing it.
-    * @param dataType - Type of column we are comparing to.
-    * @param json - Value.
-    * @return Expression - Literal representing Json Value as dataType.
+  /** Takes Json Number and creates a Expression representing it.
+    * @param dataType
+    *   \- Type of column we are comparing to.
+    * @param json
+    *   \- Value.
+    * @return
+    *   Expression - Literal representing Json Value as dataType.
     */
   def createNumericLiteral(dataType: DataType, json: JsonNumber): Expression = dataType match {
     case ByteType => Literal.create(json.toByte.get, dataType)
@@ -186,11 +196,13 @@ object ValidatorBase extends LazyLogging {
       Literal.create(json.toString, dataType)
   }
 
-  /**
-    * Creates an expression based on the json. If its a string prefixed with backtick, treat is as a column.
-    * @param dataType - Type of column we are comparing to
-    * @param json - can be a reference to column, numeric, or string.
-    * @return Expression
+  /** Creates an expression based on the json. If its a string prefixed with backtick, treat is as a column.
+    * @param dataType
+    *   \- Type of column we are comparing to
+    * @param json
+    *   \- can be a reference to column, numeric, or string.
+    * @return
+    *   Expression
     */
   def createLiteralOrUnresolvedAttribute(dataType: DataType, json: Json): Expression = {
     if (isValueColumn(json)) {
@@ -235,7 +247,8 @@ object ValidatorBase extends LazyLogging {
       case BooleanType => value.asBoolean.isDefined
       case x: DataType if x.isInstanceOf[NumericType] => areNumberTypesCompatible(dataType, value.asNumber)
       case StringType => true
-      case ut => logger.error(s"type: $ut is not implemented, please report this as bug!")
+      case ut =>
+        logger.error(s"type: $ut is not implemented, please report this as bug!")
         false // Fail Unimplemented.
     }
     logger.debug(s"areTypesCompatible colType: $dataType value[${value.getClass.getCanonicalName}]: $value ret: $ret")
@@ -243,26 +256,27 @@ object ValidatorBase extends LazyLogging {
   }
 }
 
-/**
-* CheapChecks are checks that can be combined into the same pass through a table.
-*/
+/** CheapChecks are checks that can be combined into the same pass through a table.
+  */
 trait CheapCheck extends ValidatorBase {
   def select(schema: StructType, dict: VarSubstitution): Expression
 
-  /**
-    * Run a check on a particular column on a row
+  /** Run a check on a particular column on a row
     *
-    * @param r the row under inspection
-    * @param count the number of rows total
-    * @param idx the index of the column under inspection
-    * @return true if the check fails, false if is passes
+    * @param r
+    *   the row under inspection
+    * @param count
+    *   the number of rows total
+    * @param idx
+    *   the index of the column under inspection
+    * @return
+    *   true if the check fails, false if is passes
     */
   def quickCheck(r: Row, count: Long, idx: Int): Boolean
 }
 
-/**
-* CostlyChecks are checks that require their own pass through the table and therefore are most costly.
-*/
+/** CostlyChecks are checks that require their own pass through the table and therefore are most costly.
+  */
 trait CostlyCheck extends ValidatorBase {
   def costlyCheck(df: DataFrame): Boolean
 }


### PR DESCRIPTION
Fixes #80

* Groups scala and sbt full-reformat into two separate commits
* Drops Coursier-managed scalafmt installation as unnecessary
* Adds message in CONTRIBUTING directing users to setup format-on-save
  in editors