### PR TITLE
Creates scala-steward GHA workflow

### DIFF
--- a/.github/workflows/scala-steward.yaml
+++ b/.github/workflows/scala-steward.yaml
@@ -1,0 +1,26 @@
+# This workflow will launch at 00:00 every Sunday
+on:
+  workflow_dispatch:
+  schedule:
+    # At 09:00 on day-of-month 1 and 15 
+    # https://crontab.guru/#0_9_1,15_*_*
+    - cron: '0 9 1,15 * *'
+
+name: Launch Scala Steward
+
+jobs:
+  scala-steward:
+    runs-on: ubuntu-latest
+    name: Launch Scala Steward
+    steps:
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Launch Scala Steward
+        uses: scala-steward-org/scala-steward-action@v2
+        with:
+          repo-config: .scala-steward.conf
+          github-token: ${{ secrets.REPO_GITHUB_TOKEN }}
+          author-email: 12345+octocat@users.noreply.github.com
+          author-name: "Scala Steward on GitHub Actions"


### PR DESCRIPTION
Someone posted on [our submission to the centralized Scala Steward bot][1] that the bot is offline and may be so indefinitely. Poking around, there's some movement about reviving it but the direction seems to be to set it up yourself since GHA makes that very easy except for [the credential management part][3].

For now, we'll just use the repo secret for the token even though tests won't run until after it's merged. If worse comes to worse, I'll use a personal token until I can figure out if we have an internal service account I can use.

[1]: https://github.com/scala-steward-org/repos/pull/1030
[2]: https://github.com/scala-steward-org/repos/pull/1029
[3]: https://github.com/scala-steward-org/scala-steward-action#github-token