### PR TITLE
Set junk GITHUB_TOKEN envvar for Scala Steward

### DIFF
--- a/.github/workflows/scala-steward.yaml
+++ b/.github/workflows/scala-steward.yaml
@@ -8,18 +8,18 @@ on:
 
 name: Launch Scala Steward
 
+env:
+  # This is required because SBT is configured to look at env:GITHUB_TOKEN or git:github.token or env:SHELL
+  # to get a token for publishing even when not executing the publish task. Most of the time, SHELL is set
+  # but apparently not inside GitHub Actions runners. Setting _something invalid_ satisfies the
+  # GitHub Packages plugin safely and allows the operation to proceed.
+  SHELL: "/bin/bash"
+
 jobs:
   scala-steward:
     runs-on: ubuntu-latest
     name: Launch Scala Steward
     steps:
-      - name: Configure unused GitHub Token via git
-        # This is required because SBT is configured to look at env:GITHUB_TOKEN or git:github.token or env:SHELL
-        # to get a token for publishing even when not executing the publish task. Most of the time, SHELL is set
-        # but apparently not inside GitHub Actions runners. Setting _something invalid_ satisfies the
-        # GitHub Packages plugin safely and allows the operation to proceed.
-        # We also have to initialize the git repo because we're not in a repo context when this runs.
-        run: git init . && git config github.token unused
       - name: Install JDK for Scala Steward use
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
The git method is failing because SS clones and CDs into the clone, where the github.token config is unset. So, let's try setting a SHELL variable and hope that its not going to override something important.