### PR TITLE
Blocks Spark in Scala Steward at 2.3.4

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -38,10 +38,9 @@ pullRequests.frequency = "7 days"
 #
 # Each pattern must have `groupId`, `version` and optional `artifactId`.
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
-# the following example will allow to update foo when version is 1.1.x
 updates.pin  = [
-  { groupId = "org.apache.spark", artifactId="spark-sql", version = "2.3." }
- ]
+  { groupId = "org.apache.spark", artifactId = "spark-sql", version = "2.3.4" }
+]
 
 # The dependencies which match the given pattern are NOT updated.
 #


### PR DESCRIPTION
I don't know why the `2.3.` didn't work but now that it's set to where it'll live for a bit, let's just pin there.

Closes #116 