### PR TITLE
Avoid UnsupportedClassVersionError in Scala Steward by bumping to JDK11

### DIFF
--- a/.github/workflows/scala-steward.yaml
+++ b/.github/workflows/scala-steward.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '8'
+          java-version: '11'
       - name: Launch Scala Steward
         uses: scala-steward-org/scala-steward-action@v2
         with:


### PR DESCRIPTION
An upstream library that Scala Steward depends on is now compiling against JDK11 so that's now the de facto minimum version for running it.

See https://github.com/target/data-validator/actions/runs/3591061892/jobs/6107483826#step:3:59