### PR TITLE
Create dco.yml for Developer Certificate of Origin

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,25 @@
+####
+# This file configures dco2, a tool Target uses to nudge contributors to sign-off their
+# adherence to the DCO agreement.
+#
+# dco2: https://github.com/cncf/dco2
+#
+# For more information about Target's use of the Developer Certificate of Origin standard,
+# please see https://github.com/target/.github.
+#
+# This file should be kept in sync with https://github.com/target/.github/blob/main/dco.yml
+#
+####
+# https://github.com/cncf/dco2?#remediation-commits
+allowRemediationCommits:
+  # Allow individual remediation commits
+  # https://github.com/cncf/dco2?#individual
+  individual: true
+  # DO NOT Allow third-party remediation commits
+  # https://github.com/cncf/dco2?#third-party
+  thirdParty: false
+
+require:
+  # Target contributors are NOT required to sign-off commits
+  # https://github.com/cncf/dco2?#skipping-sign-off-for-organization-members
+  members: false


### PR DESCRIPTION
Add configuration for dco2 to manage contributor sign-offs.