### PR TITLE
Add CodeQL group to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
 
 # Until Dependabot provides Scala updates, they are are handed by the Scala Steward action.
 # https://github.com/target/data-validator/blob/master/.github/workflows/scala-steward.yaml


### PR DESCRIPTION
This is now recommended since 4.37+ needs yolked updates, per github/codeql-action#4013.